### PR TITLE
multiplicative quantile regression mode

### DIFF
--- a/cyclic_boosting/__init__.py
+++ b/cyclic_boosting/__init__.py
@@ -12,7 +12,7 @@ Multiplicative Regression
 - :class:`~.CBPoissonRegressor`
 - :class:`~.CBNBinomRegressor`
 - :class:`~.CBExponential`
-- :class:`~.CBQuantileRegressor`
+- :class:`~.CBMultiplicativeQuantileRegressor`
 
 Additive Regression
 
@@ -64,7 +64,7 @@ __all__ = [
     "CBNBinomC",
     "CBClassifier",
     "CBGBSRegressor",
-    "CBQuantileRegressor",
+    "CBMultiplicativeQuantileRegressor",
     "pipeline_CBPoissonRegressor",
     "pipeline_CBNBinomRegressor",
     "pipeline_CBClassifier",

--- a/cyclic_boosting/__init__.py
+++ b/cyclic_boosting/__init__.py
@@ -12,6 +12,7 @@ Multiplicative Regression
 - :class:`~.CBPoissonRegressor`
 - :class:`~.CBNBinomRegressor`
 - :class:`~.CBExponential`
+- :class:`~.CBQuantileRegressor`
 
 Additive Regression
 
@@ -35,7 +36,7 @@ from __future__ import division, print_function
 
 
 from cyclic_boosting.base import CyclicBoostingBase
-from cyclic_boosting.regression import CBNBinomRegressor, CBPoissonRegressor
+from cyclic_boosting.regression import CBNBinomRegressor, CBPoissonRegressor, CBQuantileRegressor
 from cyclic_boosting.price import CBExponential
 from cyclic_boosting.location import CBLocationRegressor, CBLocPoissonRegressor
 from cyclic_boosting.nbinom import CBNBinomC
@@ -50,6 +51,7 @@ from cyclic_boosting.pipelines import (
     pipeline_CBLocPoissonRegressor,
     pipeline_CBNBinomC,
     pipeline_CBGBSRegressor,
+    pipeline_CBQuantileRegressor,
 )
 
 __all__ = [
@@ -62,6 +64,7 @@ __all__ = [
     "CBNBinomC",
     "CBClassifier",
     "CBGBSRegressor",
+    "CBQuantileRegressor",
     "pipeline_CBPoissonRegressor",
     "pipeline_CBNBinomRegressor",
     "pipeline_CBClassifier",
@@ -70,6 +73,7 @@ __all__ = [
     "pipeline_CBLocPoissonRegressor",
     "pipeline_CBNBinomC",
     "pipeline_CBGBSRegressor",
+    "pipeline_CBQuantileRegressor",
 ]
 
 __version__ = "1.0"

--- a/cyclic_boosting/__init__.py
+++ b/cyclic_boosting/__init__.py
@@ -36,7 +36,7 @@ from __future__ import division, print_function
 
 
 from cyclic_boosting.base import CyclicBoostingBase
-from cyclic_boosting.regression import CBNBinomRegressor, CBPoissonRegressor, CBQuantileRegressor
+from cyclic_boosting.regression import CBNBinomRegressor, CBPoissonRegressor, CBMultiplicativeQuantileRegressor
 from cyclic_boosting.price import CBExponential
 from cyclic_boosting.location import CBLocationRegressor, CBLocPoissonRegressor
 from cyclic_boosting.nbinom import CBNBinomC
@@ -51,7 +51,7 @@ from cyclic_boosting.pipelines import (
     pipeline_CBLocPoissonRegressor,
     pipeline_CBNBinomC,
     pipeline_CBGBSRegressor,
-    pipeline_CBQuantileRegressor,
+    pipeline_CBMultiplicativeQuantileRegressor,
 )
 
 __all__ = [
@@ -73,7 +73,7 @@ __all__ = [
     "pipeline_CBLocPoissonRegressor",
     "pipeline_CBNBinomC",
     "pipeline_CBGBSRegressor",
-    "pipeline_CBQuantileRegressor",
+    "pipeline_CBMultiplicativeQuantileRegressor",
 ]
 
 __version__ = "1.0"

--- a/cyclic_boosting/pipelines.py
+++ b/cyclic_boosting/pipelines.py
@@ -7,7 +7,7 @@ from cyclic_boosting import (
     CBNBinomC,
     CBClassifier,
     CBGBSRegressor,
-    CBQuantileRegressor,
+    CBMultiplicativeQuantileRegressor,
     binning,
 )
 
@@ -126,7 +126,7 @@ def pipeline_CB(
             aggregate=aggregate,
             regalpha=regalpha,
         )
-    elif estimator == CBQuantileRegressor:
+    elif estimator == CBMultiplicativeQuantileRegressor:
         estimatorCB = estimator(
             feature_groups=feature_groups,
             feature_properties=feature_properties,
@@ -205,8 +205,8 @@ def pipeline_CBGBSRegressor(**kwargs):
     return pipeline_CB(CBGBSRegressor, **kwargs)
 
 
-def pipeline_CBQuantileRegressor(**kwargs):
+def pipeline_CBMultiplicativeQuantileRegressor(**kwargs):
     """
-    Convenience function containing CBQuantileRegressor (estimator) + binning.
+    Convenience function containing CBMultiplicativeQuantileRegressor (estimator) + binning.
     """
-    return pipeline_CB(CBQuantileRegressor, **kwargs)
+    return pipeline_CB(CBMultiplicativeQuantileRegressor, **kwargs)

--- a/cyclic_boosting/pipelines.py
+++ b/cyclic_boosting/pipelines.py
@@ -7,6 +7,7 @@ from cyclic_boosting import (
     CBNBinomC,
     CBClassifier,
     CBGBSRegressor,
+    CBQuantileRegressor,
     binning,
 )
 
@@ -40,6 +41,7 @@ def pipeline_CB(
     bayes=False,
     n_steps=15,
     regalpha=0.0,
+    quantile=0.5,
 ):
     if estimator in [CBPoissonRegressor, CBLocPoissonRegressor, CBLocationRegressor, CBClassifier]:
         estimatorCB = estimator(
@@ -124,6 +126,22 @@ def pipeline_CB(
             aggregate=aggregate,
             regalpha=regalpha,
         )
+    elif estimator == CBQuantileRegressor:
+        estimatorCB = estimator(
+            feature_groups=feature_groups,
+            feature_properties=feature_properties,
+            weight_column=weight_column,
+            prior_prediction_column=prior_prediction_column,
+            minimal_loss_change=minimal_loss_change,
+            minimal_factor_change=minimal_factor_change,
+            maximal_iterations=maximal_iterations,
+            observers=observers,
+            smoother_choice=smoother_choice,
+            output_column=output_column,
+            learn_rate=learn_rate,
+            aggregate=aggregate,
+            quantile=quantile,
+        )
     else:
         raise Exception("No valid CB estimator.")
     binner = binning.BinNumberTransformer(n_bins=number_of_bins, feature_properties=feature_properties)
@@ -185,3 +203,10 @@ def pipeline_CBGBSRegressor(**kwargs):
     Convenience function containing CBGBSRegressor (estimator) + binning.
     """
     return pipeline_CB(CBGBSRegressor, **kwargs)
+
+
+def pipeline_CBQuantileRegressor(**kwargs):
+    """
+    Convenience function containing CBQuantileRegressor (estimator) + binning.
+    """
+    return pipeline_CB(CBQuantileRegressor, **kwargs)

--- a/cyclic_boosting/utils.py
+++ b/cyclic_boosting/utils.py
@@ -7,6 +7,7 @@ import numba as nb
 import numpy as np
 import pandas as pd
 import six
+import bisect
 
 _logger = logging.getLogger(__name__)
 
@@ -974,3 +975,29 @@ def get_feature_column_names(X, exclude_columns=[]):
         if col in features:
             features.remove(col)
     return features
+
+
+def continuous_quantile_from_discrete(y, quantile):
+    """
+    Calculates a continous approximation of a given quantile from an array of potentially discrete values.
+
+    Parameters
+    ----------
+    y : np.ndarray
+        variable with potentially discrete values
+    quantile : float
+        desired quantile
+
+    Returns
+    -------
+    float
+        calcualted quantile value
+    """
+    sorted_y = np.sort(y)
+    quantile_index = int(quantile * (len(y) - 1))
+    quantile_y = sorted_y[quantile_index]
+    index_low = bisect.bisect_left(sorted_y, quantile_y)
+    index_high = bisect.bisect_right(sorted_y, quantile_y)
+    if index_high > index_low:
+        quantile_y += (quantile_index - index_low) / (index_high - index_low)
+    return quantile_y

--- a/cyclic_boosting/utils.py
+++ b/cyclic_boosting/utils.py
@@ -984,7 +984,7 @@ def continuous_quantile_from_discrete(y, quantile):
     Parameters
     ----------
     y : np.ndarray
-        variable with potentially discrete values
+        containing data with `float` type (potentially discrete)
     quantile : float
         desired quantile
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,7 +15,7 @@ from cyclic_boosting.pipelines import (
     pipeline_CBNBinomRegressor,
     pipeline_CBNBinomC,
     pipeline_CBGBSRegressor,
-    pipeline_CBQuantileRegressor,
+    pipeline_CBMultiplicativeQuantileRegressor,
 )
 
 
@@ -472,7 +472,7 @@ def evaluate_quantile(y, yhat):
     return quantile_acc
 
 
-def cb_quantile_regressor_model(quantile):
+def cb_multiplicative_quantile_regressor_model(quantile):
     features = get_features()
 
     fp = feature_properties()
@@ -486,7 +486,7 @@ def cb_quantile_regressor_model(quantile):
         observers.PlottingObserver(iteration=-1),
     ]
 
-    CB_pipeline = pipeline_CBQuantileRegressor(
+    CB_pipeline = pipeline_CBMultiplicativeQuantileRegressor(
         quantile=quantile,
         feature_properties=fp,
         feature_groups=features,
@@ -500,7 +500,7 @@ def cb_quantile_regressor_model(quantile):
     return CB_pipeline
 
 
-def test_quantile_regression_median():
+def test_multiplicative_quantile_regression_median():
     np.random.seed(42)
 
     df = pd.read_csv("./tests/integration_test_data.csv")
@@ -508,7 +508,7 @@ def test_quantile_regression_median():
     X, y = prepare_data(df)
 
     quantile = 0.5
-    CB_est = cb_quantile_regressor_model(quantile)
+    CB_est = cb_multiplicative_quantile_regressor_model(quantile)
     CB_est.fit(X.copy(), y)
     # plot_CB('analysis_CB_iterfirst',
     #         [CB_est[-1].observers[0]], CB_est[-2])
@@ -524,7 +524,7 @@ def test_quantile_regression_median():
     np.testing.assert_almost_equal(mad, 1.6559, 3)
 
 
-def test_quantile_regression_90():
+def test_multiplicative_quantile_regression_90():
     np.random.seed(42)
 
     df = pd.read_csv("./tests/integration_test_data.csv")
@@ -532,7 +532,7 @@ def test_quantile_regression_90():
     X, y = prepare_data(df)
 
     quantile = 0.9
-    CB_est = cb_quantile_regressor_model(quantile)
+    CB_est = cb_multiplicative_quantile_regressor_model(quantile)
     CB_est.fit(X.copy(), y)
     # plot_CB('analysis_CB_iterfirst',
     #         [CB_est[-1].observers[0]], CB_est[-2])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,6 +15,7 @@ from cyclic_boosting.pipelines import (
     pipeline_CBNBinomRegressor,
     pipeline_CBNBinomC,
     pipeline_CBGBSRegressor,
+    pipeline_CBQuantileRegressor,
 )
 
 
@@ -464,3 +465,81 @@ def test_GBS_regression_default_features():
 
     mad = np.nanmean(np.abs(y - yhat))
     np.testing.assert_almost_equal(mad, 2.5755, 3)
+
+
+def evaluate_quantile(y, yhat):
+    quantile_acc = (y <= yhat).mean()
+    return quantile_acc
+
+
+def cb_quantile_regressor_model(quantile):
+    features = get_features()
+
+    fp = feature_properties()
+    explicit_smoothers = {
+        ("dayofyear",): SeasonalSmoother(order=3),
+        ("price_ratio",): IsotonicRegressor(increasing=False),
+    }
+
+    plobs = [
+        observers.PlottingObserver(iteration=1),
+        observers.PlottingObserver(iteration=-1),
+    ]
+
+    CB_pipeline = pipeline_CBQuantileRegressor(
+        quantile=quantile,
+        feature_properties=fp,
+        feature_groups=features,
+        observers=plobs,
+        maximal_iterations=50,
+        smoother_choice=common_smoothers.SmootherChoiceGroupBy(
+            use_regression_type=True, use_normalization=False, explicit_smoothers=explicit_smoothers
+        ),
+    )
+
+    return CB_pipeline
+
+
+def test_quantile_regression_median():
+    np.random.seed(42)
+
+    df = pd.read_csv("./tests/integration_test_data.csv")
+
+    X, y = prepare_data(df)
+
+    quantile = 0.5
+    CB_est = cb_quantile_regressor_model(quantile)
+    CB_est.fit(X.copy(), y)
+    # plot_CB('analysis_CB_iterfirst',
+    #         [CB_est[-1].observers[0]], CB_est[-2])
+    # plot_CB('analysis_CB_iterlast',
+    #         [CB_est[-1].observers[-1]], CB_est[-2])
+
+    yhat = CB_est.predict(X.copy())
+
+    quantile_acc = evaluate_quantile(y, yhat)
+    np.testing.assert_almost_equal(quantile_acc, 0.5043, 3)
+
+    mad = np.nanmean(np.abs(y - yhat))
+    np.testing.assert_almost_equal(mad, 1.6559, 3)
+
+
+def test_quantile_regression_90():
+    np.random.seed(42)
+
+    df = pd.read_csv("./tests/integration_test_data.csv")
+
+    X, y = prepare_data(df)
+
+    quantile = 0.9
+    CB_est = cb_quantile_regressor_model(quantile)
+    CB_est.fit(X.copy(), y)
+    # plot_CB('analysis_CB_iterfirst',
+    #         [CB_est[-1].observers[0]], CB_est[-2])
+    # plot_CB('analysis_CB_iterlast',
+    #         [CB_est[-1].observers[-1]], CB_est[-2])
+
+    yhat = CB_est.predict(X.copy())
+
+    quantile_acc = evaluate_quantile(y, yhat)
+    np.testing.assert_almost_equal(quantile_acc, 0.9015, 3)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,3 +36,14 @@ def test_get_feature_column_names():
     np.testing.assert_equal(features, ["a", "b", "c"])
     features = utils.get_feature_column_names(X, exclude_columns=["a"])
     np.testing.assert_equal(features, ["b", "c"])
+
+
+def test_continuous_quantile_from_discrete():
+    y = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    quantile_value = utils.continuous_quantile_from_discrete(y, 0.8)
+    assert quantile_value == 8.0
+    quantile_value = utils.continuous_quantile_from_discrete(y, 0.35)
+    assert quantile_value == 3.0
+    y = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] * 2)
+    quantile_value = utils.continuous_quantile_from_discrete(y, 0.35)
+    assert quantile_value == 3.5


### PR DESCRIPTION
Implementation of quantile regression using a numerical minimization (via scipy) of a quantile loss.
solving #2 

For now, this is done for multiplicative mode, i.e., non-negative target values, only (simply via a multiplicative model used in the loss function), but a generalization to additive mode is trivial. However, I would suggest to do such a generalization in a separate pull request (for #32 ) introducing a generic mode (using the structure implemented in this pull request) allowing for numerical minimization of arbitrary losses (i.e., also allowing likelihoods for example).