### PR TITLE
remove duplicate code from integration tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,70 @@
+import pandas as pd
+import numpy as np
+import pytest
+
+from sklearn.preprocessing import OrdinalEncoder
+from cyclic_boosting import flags
+from typing import List, Tuple, Union
+
+import os
+
+
+@pytest.fixture(scope="session")
+def prepare_data() -> Tuple[pd.DataFrame, np.ndarray]:
+    current_path = os.path.dirname(os.path.realpath(__file__))
+    filename = "integration_test_data.csv"
+    df = pd.read_csv(current_path + "/" + filename)
+
+    df["DATE"] = pd.to_datetime(df["DATE"])
+    df["dayofweek"] = df["DATE"].dt.dayofweek
+    df["dayofyear"] = df["DATE"].dt.dayofyear
+
+    df["price_ratio"] = df["SALES_PRICE"] / df["NORMAL_PRICE"]
+    df["price_ratio"].fillna(1, inplace=True)
+    df["price_ratio"].clip(0, 1, inplace=True)
+    df.loc[df["price_ratio"] == 1.0, "price_ratio"] = np.nan
+
+    enc = OrdinalEncoder(handle_unknown="use_encoded_value", unknown_value=np.nan)
+    df[["L_ID", "P_ID", "PG_ID_3"]] = enc.fit_transform(df[["L_ID", "P_ID", "PG_ID_3"]])
+
+    y = np.asarray(df["SALES"])
+    X = df.drop(columns="SALES")
+    return X, y
+
+
+@pytest.fixture(scope="session")
+def feature_properties() -> dict:
+    fp = {}
+    fp["P_ID"] = flags.IS_UNORDERED
+    fp["PG_ID_3"] = flags.IS_UNORDERED
+    fp["L_ID"] = flags.IS_UNORDERED
+    fp["dayofweek"] = flags.IS_ORDERED
+    fp["dayofyear"] = flags.IS_CONTINUOUS | flags.IS_LINEAR
+    fp["price_ratio"] = flags.IS_CONTINUOUS | flags.HAS_MISSING | flags.MISSING_NOT_LEARNED
+    fp["PROMOTION_TYPE"] = flags.IS_ORDERED
+    return fp
+
+
+@pytest.fixture(scope="session")
+def features() -> List[Union[str, tuple]]:
+    features = [
+        "dayofweek",
+        "L_ID",
+        "PG_ID_3",
+        "P_ID",
+        "PROMOTION_TYPE",
+        "price_ratio",
+        "dayofyear",
+        ("P_ID", "L_ID"),
+    ]
+    return features
+
+
+@pytest.fixture(scope="session")
+def default_features() -> List[str]:
+    return ["dayofweek", "L_ID", "PG_ID_3", "P_ID", "PROMOTION_TYPE", "price_ratio", "dayofyear"]
+
+
+@pytest.fixture(scope="session")
+def is_plot() -> bool:
+    return False

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -22,6 +22,8 @@ from cyclic_boosting.pipelines import (
 )
 from tests.utils import plot_CB, costs_mad, costs_mse
 
+np.random.seed(42)
+
 
 @pytest.fixture(scope="function")
 def cb_poisson_regressor_model(features, feature_properties):
@@ -49,7 +51,6 @@ def cb_poisson_regressor_model(features, feature_properties):
 
 
 def test_poisson_regression(is_plot, prepare_data, cb_poisson_regressor_model):
-    np.random.seed(42)
     X, y = prepare_data
 
     CB_est = cb_poisson_regressor_model
@@ -66,7 +67,6 @@ def test_poisson_regression(is_plot, prepare_data, cb_poisson_regressor_model):
 
 
 def test_poisson_regression_default_features(prepare_data, default_features, feature_properties):
-    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -81,7 +81,6 @@ def test_poisson_regression_default_features(prepare_data, default_features, fea
 
 @pytest.mark.parametrize(("feature_groups", "expected"), [(None, 1.689), ([0, 1, 4, 5], 1.950)])
 def test_poisson_regression_ndarray(prepare_data, default_features, feature_properties, feature_groups, expected):
-    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features].to_numpy()
 
@@ -96,7 +95,6 @@ def test_poisson_regression_ndarray(prepare_data, default_features, feature_prop
 
 @pytest.mark.parametrize("regressor", ["BinomRegressor", "PoissonRegressor"])
 def test_regression_ndarray_w_feature_properties(prepare_data, default_features, regressor):
-    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features].to_numpy()
 
@@ -120,7 +118,6 @@ def test_regression_ndarray_w_feature_properties(prepare_data, default_features,
 
 
 def test_poisson_regression_default_features_and_properties(is_plot, prepare_data, default_features):
-    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -144,7 +141,6 @@ def test_poisson_regression_default_features_and_properties(is_plot, prepare_dat
 
 
 def test_poisson_regression_default_features_notaggregated(prepare_data, default_features, feature_properties):
-    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -158,7 +154,6 @@ def test_poisson_regression_default_features_notaggregated(prepare_data, default
 
 
 def test_nbinom_regression_default_features(prepare_data, default_features, feature_properties):
-    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -177,7 +172,6 @@ def test_nbinom_regression_default_features(prepare_data, default_features, feat
 
 @pytest.mark.parametrize(("feature_groups", "expected"), [(None, 1.689), ([0, 1, 4, 5], 1.950)])
 def test_nbinom_regression_ndarray(prepare_data, default_features, feature_properties, feature_groups, expected):
-    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features].to_numpy()
 
@@ -234,7 +228,6 @@ def cb_exponential_regressor_model(features, feature_properties):
 
 
 def test_exponential_regression(is_plot, prepare_data, cb_exponential_regressor_model):
-    np.random.seed(42)
     X, y = prepare_data
     X.loc[X["price_ratio"] == np.nan, "price_ratio"] = 1.0
 
@@ -274,7 +267,6 @@ def cb_classifier_model(features, feature_properties):
 
 
 def test_classification(is_plot, prepare_data, cb_classifier_model):
-    np.random.seed(42)
     X, y = prepare_data
     y = y >= 3
 
@@ -291,7 +283,6 @@ def test_classification(is_plot, prepare_data, cb_classifier_model):
 
 
 def test_location_regression_default_features(is_plot, feature_properties, default_features, prepare_data):
-    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -332,7 +323,6 @@ def cb_width_model(feature_properties):
 
 
 def test_width_regression_default_features(feature_properties, default_features, prepare_data, cb_width_model):
-    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -349,7 +339,6 @@ def test_width_regression_default_features(feature_properties, default_features,
 
 
 def test_GBS_regression_default_features(is_plot, feature_properties, default_features, prepare_data):
-    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -398,7 +387,6 @@ def cb_multiplicative_quantile_regressor_model(quantile, features, feature_prope
 
 
 def test_multiplicative_quantile_regression_median(is_plot, prepare_data, features, feature_properties):
-    np.random.seed(42)
     X, y = prepare_data
     y = abs(y)
 
@@ -422,7 +410,6 @@ def test_multiplicative_quantile_regression_median(is_plot, prepare_data, featur
 
 
 def test_multiplicative_quantile_regression_90(is_plot, prepare_data, features, feature_properties):
-    np.random.seed(42)
     X, y = prepare_data
     y = abs(y)
 
@@ -443,7 +430,6 @@ def test_multiplicative_quantile_regression_90(is_plot, prepare_data, features, 
 
 
 def test_additive_quantile_regression_median(is_plot, prepare_data, default_features, feature_properties):
-    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -466,7 +452,6 @@ def test_additive_quantile_regression_median(is_plot, prepare_data, default_feat
 
 
 def test_additive_quantile_regression_90(is_plot, prepare_data, default_features, feature_properties):
-    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -486,7 +471,6 @@ def test_additive_quantile_regression_90(is_plot, prepare_data, default_features
 
 
 def test_additive_regression_mad(is_plot, prepare_data, default_features, feature_properties):
-    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -506,7 +490,6 @@ def test_additive_regression_mad(is_plot, prepare_data, default_features, featur
 
 
 def test_additive_regression_mse(is_plot, prepare_data, default_features, feature_properties):
-    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -526,7 +509,6 @@ def test_additive_regression_mse(is_plot, prepare_data, default_features, featur
 
 
 def test_multiplicative_regression_mad(is_plot, prepare_data, default_features, feature_properties):
-    np.random.seed(42)
     X, y = prepare_data
     y = abs(y)
 
@@ -548,7 +530,6 @@ def test_multiplicative_regression_mad(is_plot, prepare_data, default_features, 
 
 
 def test_multiplicative_regression_mse(is_plot, prepare_data, default_features, feature_properties):
-    np.random.seed(42)
     X, y = prepare_data
     y = abs(y)
 
@@ -576,7 +557,6 @@ def poisson_likelihood(prediction, y, weights):
 
 @pytest.mark.skip(reason="Long running time")
 def test_multiplicative_regression_likelihood(is_plot, prepare_data, default_features, feature_properties):
-    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -625,7 +605,6 @@ def cb_classifier_logloss_model(features, feature_properties):
 
 
 def test_classification_logloss(is_plot, prepare_data, cb_classifier_logloss_model):
-    np.random.seed(42)
     X, y = prepare_data
     y = y >= 3
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -22,8 +22,6 @@ from cyclic_boosting.pipelines import (
 )
 from tests.utils import plot_CB, costs_mad, costs_mse
 
-np.random.seed(42)
-
 
 @pytest.fixture(scope="function")
 def cb_poisson_regressor_model(features, feature_properties):
@@ -51,6 +49,7 @@ def cb_poisson_regressor_model(features, feature_properties):
 
 
 def test_poisson_regression(is_plot, prepare_data, cb_poisson_regressor_model):
+    np.random.seed(42)
     X, y = prepare_data
 
     CB_est = cb_poisson_regressor_model
@@ -67,6 +66,7 @@ def test_poisson_regression(is_plot, prepare_data, cb_poisson_regressor_model):
 
 
 def test_poisson_regression_default_features(prepare_data, default_features, feature_properties):
+    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -81,6 +81,7 @@ def test_poisson_regression_default_features(prepare_data, default_features, fea
 
 @pytest.mark.parametrize(("feature_groups", "expected"), [(None, 1.689), ([0, 1, 4, 5], 1.950)])
 def test_poisson_regression_ndarray(prepare_data, default_features, feature_properties, feature_groups, expected):
+    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features].to_numpy()
 
@@ -95,6 +96,7 @@ def test_poisson_regression_ndarray(prepare_data, default_features, feature_prop
 
 @pytest.mark.parametrize("regressor", ["BinomRegressor", "PoissonRegressor"])
 def test_regression_ndarray_w_feature_properties(prepare_data, default_features, regressor):
+    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features].to_numpy()
 
@@ -118,6 +120,7 @@ def test_regression_ndarray_w_feature_properties(prepare_data, default_features,
 
 
 def test_poisson_regression_default_features_and_properties(is_plot, prepare_data, default_features):
+    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -141,6 +144,7 @@ def test_poisson_regression_default_features_and_properties(is_plot, prepare_dat
 
 
 def test_poisson_regression_default_features_notaggregated(prepare_data, default_features, feature_properties):
+    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -154,6 +158,7 @@ def test_poisson_regression_default_features_notaggregated(prepare_data, default
 
 
 def test_nbinom_regression_default_features(prepare_data, default_features, feature_properties):
+    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -172,6 +177,7 @@ def test_nbinom_regression_default_features(prepare_data, default_features, feat
 
 @pytest.mark.parametrize(("feature_groups", "expected"), [(None, 1.689), ([0, 1, 4, 5], 1.950)])
 def test_nbinom_regression_ndarray(prepare_data, default_features, feature_properties, feature_groups, expected):
+    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features].to_numpy()
 
@@ -228,6 +234,7 @@ def cb_exponential_regressor_model(features, feature_properties):
 
 
 def test_exponential_regression(is_plot, prepare_data, cb_exponential_regressor_model):
+    np.random.seed(42)
     X, y = prepare_data
     X.loc[X["price_ratio"] == np.nan, "price_ratio"] = 1.0
 
@@ -267,6 +274,7 @@ def cb_classifier_model(features, feature_properties):
 
 
 def test_classification(is_plot, prepare_data, cb_classifier_model):
+    np.random.seed(42)
     X, y = prepare_data
     y = y >= 3
 
@@ -283,6 +291,7 @@ def test_classification(is_plot, prepare_data, cb_classifier_model):
 
 
 def test_location_regression_default_features(is_plot, feature_properties, default_features, prepare_data):
+    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -323,6 +332,7 @@ def cb_width_model(feature_properties):
 
 
 def test_width_regression_default_features(feature_properties, default_features, prepare_data, cb_width_model):
+    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -339,6 +349,7 @@ def test_width_regression_default_features(feature_properties, default_features,
 
 
 def test_GBS_regression_default_features(is_plot, feature_properties, default_features, prepare_data):
+    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -387,6 +398,7 @@ def cb_multiplicative_quantile_regressor_model(quantile, features, feature_prope
 
 
 def test_multiplicative_quantile_regression_median(is_plot, prepare_data, features, feature_properties):
+    np.random.seed(42)
     X, y = prepare_data
     y = abs(y)
 
@@ -406,10 +418,11 @@ def test_multiplicative_quantile_regression_median(is_plot, prepare_data, featur
     np.testing.assert_almost_equal(quantile_acc, 0.5043, 3)
 
     mad = np.nanmean(np.abs(y - yhat))
-    np.testing.assert_almost_equal(mad, 1.6559, 3)
+    np.testing.assert_almost_equal(mad, 1.6575, 3)
 
 
 def test_multiplicative_quantile_regression_90(is_plot, prepare_data, features, feature_properties):
+    np.random.seed(42)
     X, y = prepare_data
     y = abs(y)
 
@@ -430,6 +443,7 @@ def test_multiplicative_quantile_regression_90(is_plot, prepare_data, features, 
 
 
 def test_additive_quantile_regression_median(is_plot, prepare_data, default_features, feature_properties):
+    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -445,13 +459,14 @@ def test_additive_quantile_regression_median(is_plot, prepare_data, default_feat
     yhat = CB_est.predict(X.copy())
 
     quantile_acc = evaluate_quantile(y, yhat)
-    np.testing.assert_almost_equal(quantile_acc, 0.4973, 3)
+    np.testing.assert_almost_equal(quantile_acc, 0.5007, 3)
 
     mad = np.nanmean(np.abs(y - yhat))
-    np.testing.assert_almost_equal(mad, 1.6990, 3)
+    np.testing.assert_almost_equal(mad, 2.5565, 3)
 
 
 def test_additive_quantile_regression_90(is_plot, prepare_data, default_features, feature_properties):
+    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -471,6 +486,7 @@ def test_additive_quantile_regression_90(is_plot, prepare_data, default_features
 
 
 def test_additive_regression_mad(is_plot, prepare_data, default_features, feature_properties):
+    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -486,10 +502,11 @@ def test_additive_regression_mad(is_plot, prepare_data, default_features, featur
     yhat = CB_est.predict(X.copy())
 
     mad = np.nanmean(np.abs(y - yhat))
-    np.testing.assert_almost_equal(mad, 1.6990, 3)
+    np.testing.assert_almost_equal(mad, 2.5565, 3)
 
 
 def test_additive_regression_mse(is_plot, prepare_data, default_features, feature_properties):
+    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -505,10 +522,11 @@ def test_additive_regression_mse(is_plot, prepare_data, default_features, featur
     yhat = CB_est.predict(X.copy())
 
     mad = np.nanmean(np.abs(y - yhat))
-    np.testing.assert_almost_equal(mad, 1.7480, 3)
+    np.testing.assert_almost_equal(mad, 2.5735, 3)
 
 
 def test_multiplicative_regression_mad(is_plot, prepare_data, default_features, feature_properties):
+    np.random.seed(42)
     X, y = prepare_data
     y = abs(y)
 
@@ -530,6 +548,7 @@ def test_multiplicative_regression_mad(is_plot, prepare_data, default_features, 
 
 
 def test_multiplicative_regression_mse(is_plot, prepare_data, default_features, feature_properties):
+    np.random.seed(42)
     X, y = prepare_data
     y = abs(y)
 
@@ -557,6 +576,7 @@ def poisson_likelihood(prediction, y, weights):
 
 @pytest.mark.skip(reason="Long running time")
 def test_multiplicative_regression_likelihood(is_plot, prepare_data, default_features, feature_properties):
+    np.random.seed(42)
     X, y = prepare_data
     X = X[default_features]
 
@@ -605,6 +625,7 @@ def cb_classifier_logloss_model(features, feature_properties):
 
 
 def test_classification_logloss(is_plot, prepare_data, cb_classifier_logloss_model):
+    np.random.seed(42)
     X, y = prepare_data
     y = y >= 3
 
@@ -617,4 +638,4 @@ def test_classification_logloss(is_plot, prepare_data, cb_classifier_logloss_mod
     yhat = CB_est.predict(X.copy())
 
     mad = np.nanmean(np.abs(y - yhat))
-    np.testing.assert_almost_equal(mad, 0.4044, 3)
+    np.testing.assert_almost_equal(mad, 0.3811, 3)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,13 +1,11 @@
-import pandas as pd
 import numpy as np
 import pytest
 
-from sklearn.preprocessing import OrdinalEncoder
+
 from scipy.special import factorial
 
 from cyclic_boosting import flags, common_smoothers, observers
 from cyclic_boosting.smoothing.onedim import SeasonalSmoother, IsotonicRegressor
-from cyclic_boosting.plots import plot_analysis
 from cyclic_boosting.pipelines import (
     pipeline_CBPoissonRegressor,
     pipeline_CBClassifier,
@@ -22,61 +20,13 @@ from cyclic_boosting.pipelines import (
     pipeline_CBAdditiveGenericCRegressor,
     pipeline_CBGenericClassifier,
 )
+from tests.utils import plot_CB, costs_mad, costs_mse
+
+np.random.seed(42)
 
 
-def plot_CB(filename, plobs, binner):
-    for i, p in enumerate(plobs):
-        plot_analysis(plot_observer=p, file_obj=filename + "_{}".format(i), use_tightlayout=False, binners=[binner])
-
-
-def prepare_data(df):
-    df["DATE"] = pd.to_datetime(df["DATE"])
-    df["dayofweek"] = df["DATE"].dt.dayofweek
-    df["dayofyear"] = df["DATE"].dt.dayofyear
-
-    df["price_ratio"] = df["SALES_PRICE"] / df["NORMAL_PRICE"]
-    df["price_ratio"].fillna(1, inplace=True)
-    df["price_ratio"].clip(0, 1, inplace=True)
-    df.loc[df["price_ratio"] == 1.0, "price_ratio"] = np.nan
-
-    enc = OrdinalEncoder(handle_unknown="use_encoded_value", unknown_value=np.nan)
-    df[["L_ID", "P_ID", "PG_ID_3"]] = enc.fit_transform(df[["L_ID", "P_ID", "PG_ID_3"]])
-
-    y = np.asarray(df["SALES"])
-    X = df.drop(columns="SALES")
-    return X, y
-
-
-def feature_properties():
-    fp = {}
-    fp["P_ID"] = flags.IS_UNORDERED
-    fp["PG_ID_3"] = flags.IS_UNORDERED
-    fp["L_ID"] = flags.IS_UNORDERED
-    fp["dayofweek"] = flags.IS_ORDERED
-    fp["dayofyear"] = flags.IS_CONTINUOUS | flags.IS_LINEAR
-    fp["price_ratio"] = flags.IS_CONTINUOUS | flags.HAS_MISSING | flags.MISSING_NOT_LEARNED
-    fp["PROMOTION_TYPE"] = flags.IS_ORDERED
-    return fp
-
-
-def get_features():
-    features = [
-        "dayofweek",
-        "L_ID",
-        "PG_ID_3",
-        "P_ID",
-        "PROMOTION_TYPE",
-        "price_ratio",
-        "dayofyear",
-        ("P_ID", "L_ID"),
-    ]
-    return features
-
-
-def cb_poisson_regressor_model():
-    features = get_features()
-
-    fp = feature_properties()
+@pytest.fixture(scope="function")
+def cb_poisson_regressor_model(features, feature_properties):
     explicit_smoothers = {
         ("dayofyear",): SeasonalSmoother(order=3),
         ("price_ratio",): IsotonicRegressor(increasing=False),
@@ -88,7 +38,7 @@ def cb_poisson_regressor_model():
     ]
 
     CB_pipeline = pipeline_CBPoissonRegressor(
-        feature_properties=fp,
+        feature_properties=feature_properties,
         feature_groups=features,
         observers=plobs,
         maximal_iterations=50,
@@ -100,19 +50,15 @@ def cb_poisson_regressor_model():
     return CB_pipeline
 
 
-def test_poisson_regression():
-    np.random.seed(42)
+def test_poisson_regression(is_plot, prepare_data, cb_poisson_regressor_model):
+    X, y = prepare_data
 
-    df = pd.read_csv("./tests/integration_test_data.csv")
-
-    X, y = prepare_data(df)
-
-    CB_est = cb_poisson_regressor_model()
+    CB_est = cb_poisson_regressor_model
     CB_est.fit(X.copy(), y)
-    # plot_CB('analysis_CB_iterfirst',
-    #         [CB_est[-1].observers[0]], CB_est[-2])
-    # plot_CB('analysis_CB_iterlast',
-    #         [CB_est[-1].observers[-1]], CB_est[-2])
+
+    if is_plot:
+        plot_CB("analysis_CB_iterfirst", [CB_est[-1].observers[0]], CB_est[-2])
+        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
     yhat = CB_est.predict(X.copy())
 
@@ -120,16 +66,11 @@ def test_poisson_regression():
     np.testing.assert_almost_equal(mad, 1.6997, 3)
 
 
-def test_poisson_regression_default_features():
-    np.random.seed(42)
+def test_poisson_regression_default_features(prepare_data, default_features, feature_properties):
+    X, y = prepare_data
+    X = X[default_features]
 
-    df = pd.read_csv("./tests/integration_test_data.csv")
-
-    X, y = prepare_data(df)
-    X = X[["dayofweek", "L_ID", "PG_ID_3", "P_ID", "PROMOTION_TYPE", "price_ratio", "dayofyear"]]
-
-    fp = feature_properties()
-    CB_est = pipeline_CBPoissonRegressor(feature_properties=fp)
+    CB_est = pipeline_CBPoissonRegressor(feature_properties=feature_properties)
     CB_est.fit(X.copy(), y)
 
     yhat = CB_est.predict(X.copy())
@@ -139,16 +80,11 @@ def test_poisson_regression_default_features():
 
 
 @pytest.mark.parametrize(("feature_groups", "expected"), [(None, 1.689), ([0, 1, 4, 5], 1.950)])
-def test_poisson_regression_ndarray(feature_groups, expected):
-    np.random.seed(42)
+def test_poisson_regression_ndarray(prepare_data, default_features, feature_properties, feature_groups, expected):
+    X, y = prepare_data
+    X = X[default_features].to_numpy()
 
-    df = pd.read_csv("./tests/integration_test_data.csv")
-
-    X, y = prepare_data(df)
-    X = X[["dayofweek", "L_ID", "PG_ID_3", "P_ID", "PROMOTION_TYPE", "price_ratio", "dayofyear"]].to_numpy()
-
-    fp = feature_properties()
-    CB_est = pipeline_CBPoissonRegressor(feature_groups=feature_groups, feature_properties=fp)
+    CB_est = pipeline_CBPoissonRegressor(feature_groups=feature_groups, feature_properties=feature_properties)
     CB_est.fit(X.copy(), y)
 
     yhat = CB_est.predict(X.copy())
@@ -158,13 +94,9 @@ def test_poisson_regression_ndarray(feature_groups, expected):
 
 
 @pytest.mark.parametrize("regressor", ["BinomRegressor", "PoissonRegressor"])
-def test_regression_ndarray_w_feature_properties(regressor):
-    np.random.seed(42)
-
-    df = pd.read_csv("./tests/integration_test_data.csv")
-
-    X, y = prepare_data(df)
-    X = X[["dayofweek", "L_ID", "PG_ID_3", "P_ID", "PROMOTION_TYPE", "price_ratio", "dayofyear"]].to_numpy()
+def test_regression_ndarray_w_feature_properties(prepare_data, default_features, regressor):
+    X, y = prepare_data
+    X = X[default_features].to_numpy()
 
     fp = {
         0: flags.IS_UNORDERED,
@@ -185,13 +117,9 @@ def test_regression_ndarray_w_feature_properties(regressor):
     np.testing.assert_almost_equal(mad, 1.695, 3)
 
 
-def test_poisson_regression_default_features_and_properties():
-    np.random.seed(42)
-
-    df = pd.read_csv("./tests/integration_test_data.csv")
-
-    X, y = prepare_data(df)
-    X = X[["dayofweek", "L_ID", "PG_ID_3", "P_ID", "PROMOTION_TYPE", "price_ratio", "dayofyear"]]
+def test_poisson_regression_default_features_and_properties(is_plot, prepare_data, default_features):
+    X, y = prepare_data
+    X = X[default_features]
 
     plobs = [
         observers.PlottingObserver(iteration=1),
@@ -201,10 +129,10 @@ def test_poisson_regression_default_features_and_properties():
         observers=plobs,
     )
     CB_est.fit(X.copy(), y)
-    # plot_CB('analysis_CB_iterfirst',
-    #         [CB_est[-1].observers[0]], CB_est[-2])
-    # plot_CB('analysis_CB_iterlast',
-    #         [CB_est[-1].observers[-1]], CB_est[-2])
+
+    if is_plot:
+        plot_CB("analysis_CB_iterfirst", [CB_est[-1].observers[0]], CB_est[-2])
+        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
     yhat = CB_est.predict(X.copy())
 
@@ -212,16 +140,11 @@ def test_poisson_regression_default_features_and_properties():
     np.testing.assert_almost_equal(mad, 1.6982, 3)
 
 
-def test_poisson_regression_default_features_notaggregated():
-    np.random.seed(42)
+def test_poisson_regression_default_features_notaggregated(prepare_data, default_features, feature_properties):
+    X, y = prepare_data
+    X = X[default_features]
 
-    df = pd.read_csv("./tests/integration_test_data.csv")
-
-    X, y = prepare_data(df)
-    X = X[["dayofweek", "L_ID", "PG_ID_3", "P_ID", "PROMOTION_TYPE", "price_ratio", "dayofyear"]]
-
-    fp = feature_properties()
-    CB_est = pipeline_CBPoissonRegressor(feature_properties=fp, aggregate=False)
+    CB_est = pipeline_CBPoissonRegressor(feature_properties=feature_properties, aggregate=False)
     CB_est.fit(X.copy(), y)
 
     yhat = CB_est.predict(X.copy())
@@ -230,17 +153,12 @@ def test_poisson_regression_default_features_notaggregated():
     np.testing.assert_almost_equal(mad, 1.7144, 3)
 
 
-def test_nbinom_regression_default_features():
-    np.random.seed(42)
+def test_nbinom_regression_default_features(prepare_data, default_features, feature_properties):
+    X, y = prepare_data
+    X = X[default_features]
 
-    df = pd.read_csv("./tests/integration_test_data.csv")
-
-    X, y = prepare_data(df)
-    X = X[["dayofweek", "L_ID", "PG_ID_3", "P_ID", "PROMOTION_TYPE", "price_ratio", "dayofyear"]]
-
-    fp = feature_properties()
     CB_est = pipeline_CBNBinomRegressor(
-        feature_properties=fp,
+        feature_properties=feature_properties,
         a=1.2,
         c=0.1,
     )
@@ -253,15 +171,11 @@ def test_nbinom_regression_default_features():
 
 
 @pytest.mark.parametrize(("feature_groups", "expected"), [(None, 1.689), ([0, 1, 4, 5], 1.950)])
-def test_nbinom_regression_ndarray(feature_groups, expected):
-    np.random.seed(42)
+def test_nbinom_regression_ndarray(prepare_data, default_features, feature_properties, feature_groups, expected):
+    X, y = prepare_data
+    X = X[default_features].to_numpy()
 
-    df = pd.read_csv("./tests/integration_test_data.csv")
-
-    X, y = prepare_data(df)
-    X = X[["dayofweek", "L_ID", "PG_ID_3", "P_ID", "PROMOTION_TYPE", "price_ratio", "dayofyear"]].to_numpy()
-
-    fp = feature_properties()
+    fp = feature_properties
     CB_est = pipeline_CBNBinomRegressor(
         feature_groups=feature_groups,
         feature_properties=fp,
@@ -274,8 +188,9 @@ def test_nbinom_regression_ndarray(feature_groups, expected):
     np.testing.assert_almost_equal(mad, expected, 3)
 
 
-def cb_exponential_regressor_model():
-    features = get_features()
+@pytest.fixture(scope="function")
+def cb_exponential_regressor_model(features, feature_properties):
+    features = features
     features.remove("price_ratio")
     price_features = [
         "L_ID",
@@ -286,7 +201,7 @@ def cb_exponential_regressor_model():
         "dayofweek",
     ]
 
-    fp = feature_properties()
+    feature_properties = feature_properties
     explicit_smoothers = {
         ("dayofyear",): SeasonalSmoother(order=3),
         ("price_ratio",): IsotonicRegressor(increasing=False),
@@ -298,7 +213,7 @@ def cb_exponential_regressor_model():
     ]
 
     CB_pipeline = pipeline_CBExponential(
-        feature_properties=fp,
+        feature_properties=feature_properties,
         standard_feature_groups=features,
         external_feature_groups=price_features,
         external_colname="price_ratio",
@@ -312,20 +227,16 @@ def cb_exponential_regressor_model():
     return CB_pipeline
 
 
-def test_exponential_regression():
-    np.random.seed(42)
+def test_exponential_regression(is_plot, prepare_data, cb_exponential_regressor_model):
+    X, y = prepare_data
+    X.loc[X["price_ratio"] == np.nan, "price_ratio"] = 1.0
 
-    df = pd.read_csv("./tests/integration_test_data.csv")
-
-    X, y = prepare_data(df)
-    X.loc[df["price_ratio"] == np.nan, "price_ratio"] = 1.0
-
-    CB_est = cb_exponential_regressor_model()
+    CB_est = cb_exponential_regressor_model
     CB_est.fit(X.copy(), y)
-    # plot_CB('analysis_CB_iterfirst',
-    #         [CB_est[-1].observers[0]], CB_est[-2])
-    # plot_CB('analysis_CB_iterlast',
-    #         [CB_est[-1].observers[-1]], CB_est[-2])
+
+    if is_plot:
+        plot_CB("analysis_CB_iterfirst", [CB_est[-1].observers[0]], CB_est[-2])
+        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
     yhat = CB_est.predict(X.copy())
 
@@ -333,10 +244,8 @@ def test_exponential_regression():
     np.testing.assert_almost_equal(mad, 1.7203, 3)
 
 
-def cb_classifier_model():
-    features = get_features()
-
-    fp = feature_properties()
+@pytest.fixture(scope="function")
+def cb_classifier_model(features, feature_properties):
     explicit_smoothers = {
         ("dayofyear",): SeasonalSmoother(order=3),
         ("price_ratio",): IsotonicRegressor(increasing=False),
@@ -345,7 +254,7 @@ def cb_classifier_model():
     plobs = [observers.PlottingObserver(iteration=-1)]
 
     CB_pipeline = pipeline_CBClassifier(
-        feature_properties=fp,
+        feature_properties=feature_properties,
         feature_groups=features,
         observers=plobs,
         maximal_iterations=50,
@@ -357,18 +266,15 @@ def cb_classifier_model():
     return CB_pipeline
 
 
-def test_classification():
-    np.random.seed(42)
-
-    df = pd.read_csv("./tests/integration_test_data.csv")
-
-    X, y = prepare_data(df)
+def test_classification(is_plot, prepare_data, cb_classifier_model):
+    X, y = prepare_data
     y = y >= 3
 
-    CB_est = cb_classifier_model()
+    CB_est = cb_classifier_model
     CB_est.fit(X.copy(), y)
-    # plot_CB('analysis_CB_iterlast',
-    #         [CB_est[-1].observers[-1]], CB_est[-2])
+
+    if is_plot:
+        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
     yhat = CB_est.predict(X.copy())
 
@@ -376,25 +282,17 @@ def test_classification():
     np.testing.assert_almost_equal(mad, 0.3075, 3)
 
 
-def test_location_regression_default_features():
-    np.random.seed(42)
+def test_location_regression_default_features(is_plot, feature_properties, default_features, prepare_data):
+    X, y = prepare_data
+    X = X[default_features]
 
-    df = pd.read_csv("./tests/integration_test_data.csv")
+    fp = feature_properties
 
-    X, y = prepare_data(df)
-    X = X[["dayofweek", "L_ID", "PG_ID_3", "P_ID", "PROMOTION_TYPE", "price_ratio", "dayofyear"]]
-
-    fp = feature_properties()
-    # plobs = [
-    #     observers.PlottingObserver(iteration=-1)
-    # ]
-    CB_est = pipeline_CBLocationRegressor(
-        # observers=plobs,
-        feature_properties=fp
-    )
+    CB_est = pipeline_CBLocationRegressor(feature_properties=fp)
     CB_est.fit(X.copy(), y)
-    # plot_CB('analysis_CB_iterlast',
-    #         [CB_est[-1].observers[-1]], CB_est[-2])
+
+    if is_plot:
+        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
     yhat = CB_est.predict(X.copy())
 
@@ -402,17 +300,17 @@ def test_location_regression_default_features():
     np.testing.assert_almost_equal(mad, 1.7511, 3)
 
 
-def cb_width_model():
+@pytest.fixture(scope="function")
+def cb_width_model(feature_properties):
     features = ["dayofweek", "L_ID", "PG_ID_3", "PROMOTION_TYPE"]
 
-    fp = feature_properties()
     explicit_smoothers = {}
 
     plobs = [observers.PlottingObserver(iteration=-1)]
 
     CB_pipeline = pipeline_CBNBinomC(
         mean_prediction_column="yhat_mean",
-        feature_properties=fp,
+        feature_properties=feature_properties,
         feature_groups=features,
         observers=plobs,
         maximal_iterations=50,
@@ -424,47 +322,33 @@ def cb_width_model():
     return CB_pipeline
 
 
-def test_width_regression_default_features():
-    np.random.seed(42)
+def test_width_regression_default_features(feature_properties, default_features, prepare_data, cb_width_model):
+    X, y = prepare_data
+    X = X[default_features]
 
-    df = pd.read_csv("./tests/integration_test_data.csv")
-
-    X, y = prepare_data(df)
-    X = X[["dayofweek", "L_ID", "PG_ID_3", "P_ID", "PROMOTION_TYPE", "price_ratio", "dayofyear"]]
-
-    fp = feature_properties()
+    fp = feature_properties
     CB_est = pipeline_CBPoissonRegressor(feature_properties=fp)
     CB_est.fit(X.copy(), y)
     yhat = CB_est.predict(X.copy())
     X["yhat_mean"] = yhat
 
-    CB_est_width = cb_width_model()
+    CB_est_width = cb_width_model
     CB_est_width.fit(X.copy(), y)
     c = CB_est_width.predict(X.copy())
     np.testing.assert_almost_equal(c.mean(), 0.365, 3)
 
 
-def test_GBS_regression_default_features():
-    np.random.seed(42)
-
-    df = pd.read_csv("./tests/integration_test_data.csv")
-
-    X, y = prepare_data(df)
-    X = X[["dayofweek", "L_ID", "PG_ID_3", "P_ID", "PROMOTION_TYPE", "price_ratio", "dayofyear"]]
+def test_GBS_regression_default_features(is_plot, feature_properties, default_features, prepare_data):
+    X, y = prepare_data
+    X = X[default_features]
 
     y[1000:10000] = -y[1000:10000]
 
-    fp = feature_properties()
-    # plobs = [
-    #     observers.PlottingObserver(iteration=-1)
-    # ]
-    CB_est = pipeline_CBGBSRegressor(
-        # observers=plobs,
-        feature_properties=fp
-    )
+    CB_est = pipeline_CBGBSRegressor(feature_properties=feature_properties)
     CB_est.fit(X.copy(), y)
-    # plot_CB('analysis_CB_iterlast',
-    #         [CB_est[-1].observers[-1]], CB_est[-2])
+
+    if is_plot:
+        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
     yhat = CB_est.predict(X.copy())
 
@@ -477,10 +361,7 @@ def evaluate_quantile(y, yhat):
     return quantile_acc
 
 
-def cb_multiplicative_quantile_regressor_model(quantile):
-    features = get_features()
-
-    fp = feature_properties()
+def cb_multiplicative_quantile_regressor_model(quantile, features, feature_properties):
     explicit_smoothers = {
         ("dayofyear",): SeasonalSmoother(order=3),
         ("price_ratio",): IsotonicRegressor(increasing=False),
@@ -493,7 +374,7 @@ def cb_multiplicative_quantile_regressor_model(quantile):
 
     CB_pipeline = pipeline_CBMultiplicativeQuantileRegressor(
         quantile=quantile,
-        feature_properties=fp,
+        feature_properties=feature_properties,
         feature_groups=features,
         observers=plobs,
         maximal_iterations=50,
@@ -505,20 +386,19 @@ def cb_multiplicative_quantile_regressor_model(quantile):
     return CB_pipeline
 
 
-def test_multiplicative_quantile_regression_median():
-    np.random.seed(42)
-
-    df = pd.read_csv("./tests/integration_test_data.csv")
-
-    X, y = prepare_data(df)
+def test_multiplicative_quantile_regression_median(is_plot, prepare_data, features, feature_properties):
+    X, y = prepare_data
+    y = abs(y)
 
     quantile = 0.5
-    CB_est = cb_multiplicative_quantile_regressor_model(quantile)
+    CB_est = cb_multiplicative_quantile_regressor_model(
+        quantile=quantile, features=features, feature_properties=feature_properties
+    )
     CB_est.fit(X.copy(), y)
-    # plot_CB('analysis_CB_iterfirst',
-    #         [CB_est[-1].observers[0]], CB_est[-2])
-    # plot_CB('analysis_CB_iterlast',
-    #         [CB_est[-1].observers[-1]], CB_est[-2])
+
+    if is_plot:
+        plot_CB("analysis_CB_iterfirst", [CB_est[-1].observers[0]], CB_est[-2])
+        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
     yhat = CB_est.predict(X.copy())
 
@@ -529,20 +409,19 @@ def test_multiplicative_quantile_regression_median():
     np.testing.assert_almost_equal(mad, 1.6559, 3)
 
 
-def test_multiplicative_quantile_regression_90():
-    np.random.seed(42)
-
-    df = pd.read_csv("./tests/integration_test_data.csv")
-
-    X, y = prepare_data(df)
+def test_multiplicative_quantile_regression_90(is_plot, prepare_data, features, feature_properties):
+    X, y = prepare_data
+    y = abs(y)
 
     quantile = 0.9
-    CB_est = cb_multiplicative_quantile_regressor_model(quantile)
+    CB_est = cb_multiplicative_quantile_regressor_model(
+        quantile=quantile, features=features, feature_properties=feature_properties
+    )
     CB_est.fit(X.copy(), y)
-    # plot_CB('analysis_CB_iterfirst',
-    #         [CB_est[-1].observers[0]], CB_est[-2])
-    # plot_CB('analysis_CB_iterlast',
-    #         [CB_est[-1].observers[-1]], CB_est[-2])
+
+    if is_plot:
+        plot_CB("analysis_CB_iterfirst", [CB_est[-1].observers[0]], CB_est[-2])
+        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
     yhat = CB_est.predict(X.copy())
 
@@ -550,26 +429,18 @@ def test_multiplicative_quantile_regression_90():
     np.testing.assert_almost_equal(quantile_acc, 0.9015, 3)
 
 
-def test_additive_quantile_regression_median():
-    np.random.seed(42)
+def test_additive_quantile_regression_median(is_plot, prepare_data, default_features, feature_properties):
+    X, y = prepare_data
+    X = X[default_features]
 
-    df = pd.read_csv("./tests/integration_test_data.csv")
-
-    X, y = prepare_data(df)
-    X = X[["dayofweek", "L_ID", "PG_ID_3", "P_ID", "PROMOTION_TYPE", "price_ratio", "dayofyear"]]
-
-    fp = feature_properties()
-    # plobs = [
-    #     observers.PlottingObserver(iteration=-1)
-    # ]
     CB_est = pipeline_CBAdditiveQuantileRegressor(
-        # observers=plobs,
-        feature_properties=fp,
+        feature_properties=feature_properties,
         quantile=0.5,
     )
     CB_est.fit(X.copy(), y)
-    # plot_CB('analysis_CB_iterlast',
-    #         [CB_est[-1].observers[-1]], CB_est[-2])
+
+    if is_plot:
+        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
     yhat = CB_est.predict(X.copy())
 
@@ -580,26 +451,18 @@ def test_additive_quantile_regression_median():
     np.testing.assert_almost_equal(mad, 1.6990, 3)
 
 
-def test_additive_quantile_regression_90():
-    np.random.seed(42)
+def test_additive_quantile_regression_90(is_plot, prepare_data, default_features, feature_properties):
+    X, y = prepare_data
+    X = X[default_features]
 
-    df = pd.read_csv("./tests/integration_test_data.csv")
-
-    X, y = prepare_data(df)
-    X = X[["dayofweek", "L_ID", "PG_ID_3", "P_ID", "PROMOTION_TYPE", "price_ratio", "dayofyear"]]
-
-    fp = feature_properties()
-    # plobs = [
-    #     observers.PlottingObserver(iteration=-1)
-    # ]
     CB_est = pipeline_CBAdditiveQuantileRegressor(
-        # observers=plobs,
-        feature_properties=fp,
+        feature_properties=feature_properties,
         quantile=0.9,
     )
     CB_est.fit(X.copy(), y)
-    # plot_CB('analysis_CB_iterlast',
-    #         [CB_est[-1].observers[-1]], CB_est[-2])
+
+    if is_plot:
+        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
     yhat = CB_est.predict(X.copy())
 
@@ -607,34 +470,18 @@ def test_additive_quantile_regression_90():
     np.testing.assert_almost_equal(quantile_acc, 0.8969, 3)
 
 
-def costs_mad(prediction, y, weights):
-    return np.nanmean(np.abs(y - prediction))
+def test_additive_regression_mad(is_plot, prepare_data, default_features, feature_properties):
+    X, y = prepare_data
+    X = X[default_features]
 
-
-def costs_mse(prediction, y, weights):
-    return np.nanmean(np.square(y - prediction))
-
-
-def test_additive_regression_mad():
-    np.random.seed(42)
-
-    df = pd.read_csv("./tests/integration_test_data.csv")
-
-    X, y = prepare_data(df)
-    X = X[["dayofweek", "L_ID", "PG_ID_3", "P_ID", "PROMOTION_TYPE", "price_ratio", "dayofyear"]]
-
-    fp = feature_properties()
-    # plobs = [
-    #     observers.PlottingObserver(iteration=-1)
-    # ]
     CB_est = pipeline_CBAdditiveGenericCRegressor(
-        # observers=plobs,
-        feature_properties=fp,
+        feature_properties=feature_properties,
         costs=costs_mad,
     )
     CB_est.fit(X.copy(), y)
-    # plot_CB('analysis_CB_iterlast',
-    #         [CB_est[-1].observers[-1]], CB_est[-2])
+
+    if is_plot:
+        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
     yhat = CB_est.predict(X.copy())
 
@@ -642,26 +489,18 @@ def test_additive_regression_mad():
     np.testing.assert_almost_equal(mad, 1.6990, 3)
 
 
-def test_additive_regression_mse():
-    np.random.seed(42)
+def test_additive_regression_mse(is_plot, prepare_data, default_features, feature_properties):
+    X, y = prepare_data
+    X = X[default_features]
 
-    df = pd.read_csv("./tests/integration_test_data.csv")
-
-    X, y = prepare_data(df)
-    X = X[["dayofweek", "L_ID", "PG_ID_3", "P_ID", "PROMOTION_TYPE", "price_ratio", "dayofyear"]]
-
-    fp = feature_properties()
-    # plobs = [
-    #     observers.PlottingObserver(iteration=-1)
-    # ]
     CB_est = pipeline_CBAdditiveGenericCRegressor(
-        # observers=plobs,
-        feature_properties=fp,
+        feature_properties=feature_properties,
         costs=costs_mse,
     )
     CB_est.fit(X.copy(), y)
-    # plot_CB('analysis_CB_iterlast',
-    #         [CB_est[-1].observers[-1]], CB_est[-2])
+
+    if is_plot:
+        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
     yhat = CB_est.predict(X.copy())
 
@@ -669,26 +508,20 @@ def test_additive_regression_mse():
     np.testing.assert_almost_equal(mad, 1.7480, 3)
 
 
-def test_multiplicative_regression_mad():
-    np.random.seed(42)
+def test_multiplicative_regression_mad(is_plot, prepare_data, default_features, feature_properties):
+    X, y = prepare_data
+    y = abs(y)
 
-    df = pd.read_csv("./tests/integration_test_data.csv")
+    X = X[default_features]
 
-    X, y = prepare_data(df)
-    X = X[["dayofweek", "L_ID", "PG_ID_3", "P_ID", "PROMOTION_TYPE", "price_ratio", "dayofyear"]]
-
-    fp = feature_properties()
-    # plobs = [
-    #     observers.PlottingObserver(iteration=-1)
-    # ]
     CB_est = pipeline_CBMultiplicativeGenericCRegressor(
-        # observers=plobs,
-        feature_properties=fp,
+        feature_properties=feature_properties,
         costs=costs_mad,
     )
     CB_est.fit(X.copy(), y)
-    # plot_CB('analysis_CB_iterlast',
-    #         [CB_est[-1].observers[-1]], CB_est[-2])
+
+    if is_plot:
+        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
     yhat = CB_est.predict(X.copy())
 
@@ -696,26 +529,20 @@ def test_multiplicative_regression_mad():
     np.testing.assert_almost_equal(mad, 1.6705, 3)
 
 
-def test_multiplicative_regression_mse():
-    np.random.seed(42)
+def test_multiplicative_regression_mse(is_plot, prepare_data, default_features, feature_properties):
+    X, y = prepare_data
+    y = abs(y)
 
-    df = pd.read_csv("./tests/integration_test_data.csv")
+    X = X[default_features]
 
-    X, y = prepare_data(df)
-    X = X[["dayofweek", "L_ID", "PG_ID_3", "P_ID", "PROMOTION_TYPE", "price_ratio", "dayofyear"]]
-
-    fp = feature_properties()
-    # plobs = [
-    #     observers.PlottingObserver(iteration=-1)
-    # ]
     CB_est = pipeline_CBMultiplicativeGenericCRegressor(
-        # observers=plobs,
-        feature_properties=fp,
+        feature_properties=feature_properties,
         costs=costs_mse,
     )
     CB_est.fit(X.copy(), y)
-    # plot_CB('analysis_CB_iterlast',
-    #         [CB_est[-1].observers[-1]], CB_est[-2])
+
+    if is_plot:
+        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
     yhat = CB_est.predict(X.copy())
 
@@ -728,32 +555,24 @@ def poisson_likelihood(prediction, y, weights):
     return negative_log_likelihood
 
 
-# commented out due to rather long runtime
-# def test_multiplicative_regression_likelihood():
-#     np.random.seed(42)
+@pytest.mark.skip(reason="Long running time")
+def test_multiplicative_regression_likelihood(is_plot, prepare_data, default_features, feature_properties):
+    X, y = prepare_data
+    X = X[default_features]
 
-#     df = pd.read_csv("./tests/integration_test_data.csv")
+    CB_est = pipeline_CBMultiplicativeGenericCRegressor(
+        feature_properties=feature_properties,
+        costs=poisson_likelihood,
+    )
+    CB_est.fit(X.copy(), y)
 
-#     X, y = prepare_data(df)
-#     X = X[["dayofweek", "L_ID", "PG_ID_3", "P_ID", "PROMOTION_TYPE", "price_ratio", "dayofyear"]]
+    if is_plot:
+        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
-#     fp = feature_properties()
-#     # plobs = [
-#     #     observers.PlottingObserver(iteration=-1)
-#     # ]
-#     CB_est = pipeline_CBMultiplicativeGenericCRegressor(
-#         # observers=plobs,
-#         feature_properties=fp,
-#         costs=poisson_likelihood,
-#     )
-#     CB_est.fit(X.copy(), y)
-#     # plot_CB('analysis_CB_iterlast',
-#     #         [CB_est[-1].observers[-1]], CB_est[-2])
+    yhat = CB_est.predict(X.copy())
 
-#     yhat = CB_est.predict(X.copy())
-
-#     mad = np.nanmean(np.abs(y - yhat))
-#     np.testing.assert_almost_equal(mad, 1.9310, 3)
+    mad = np.nanmean(np.abs(y - yhat))
+    np.testing.assert_almost_equal(mad, 1.9310, 3)
 
 
 def costs_logloss(prediction, y, weights):
@@ -762,10 +581,8 @@ def costs_logloss(prediction, y, weights):
     return -np.nanmean(y * np.log(prediction) + (1 - y) * np.log(1 - prediction))
 
 
-def cb_classifier_logloss_model():
-    features = get_features()
-
-    fp = feature_properties()
+@pytest.fixture(scope="function")
+def cb_classifier_logloss_model(features, feature_properties):
     explicit_smoothers = {
         ("dayofyear",): SeasonalSmoother(order=3),
         ("price_ratio",): IsotonicRegressor(increasing=False),
@@ -774,7 +591,7 @@ def cb_classifier_logloss_model():
     plobs = [observers.PlottingObserver(iteration=-1)]
 
     CB_pipeline = pipeline_CBGenericClassifier(
-        feature_properties=fp,
+        feature_properties=feature_properties,
         feature_groups=features,
         observers=plobs,
         maximal_iterations=50,
@@ -787,18 +604,15 @@ def cb_classifier_logloss_model():
     return CB_pipeline
 
 
-def test_classification_logloss():
-    np.random.seed(42)
-
-    df = pd.read_csv("./tests/integration_test_data.csv")
-
-    X, y = prepare_data(df)
+def test_classification_logloss(is_plot, prepare_data, cb_classifier_logloss_model):
+    X, y = prepare_data
     y = y >= 3
 
-    CB_est = cb_classifier_logloss_model()
+    CB_est = cb_classifier_logloss_model
     CB_est.fit(X.copy(), y)
-    # plot_CB('analysis_CB_iterlast',
-    #         [CB_est[-1].observers[-1]], CB_est[-2])
+
+    if is_plot:
+        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
     yhat = CB_est.predict(X.copy())
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from cyclic_boosting.binning import BinNumberTransformer
+from cyclic_boosting.plots import plot_analysis
+
+from typing import Optional
+
+
+def plot_CB(filename: str, plobs: list, binner: Optional[BinNumberTransformer] = None):
+    for i, p in enumerate(plobs):
+        plot_analysis(plot_observer=p, file_obj=filename + "_{}".format(i), use_tightlayout=False, binners=[binner])
+
+
+def costs_mad(prediction, y, weights):
+    return np.nanmean(np.abs(y - prediction))
+
+
+def costs_mse(prediction, y, weights):
+    return np.nanmean(np.square(y - prediction))


### PR DESCRIPTION
I am seeing some test flakiness which disappears once I repeat the failing tests with `pytest tests/test_integration.py --lf`. This suggests that there might be a problem with the random seed, although it is not obvious to me where since some of the other tests pass consistently.