### PR TITLE
Add feature importance calculation

### DIFF
--- a/cyclic_boosting/base.py
+++ b/cyclic_boosting/base.py
@@ -662,7 +662,7 @@ class CyclicBoostingBase(
             yield i, feature, prefit_data[i]
 
     def fit(
-        self, X: np.ndarray, y: Optional[np.ndarray] = None, fit_mode: int = 0
+        self, X: Union[pd.DataFrame, np.ndarray], y: Optional[np.ndarray] = None, fit_mode: int = 0
     ) -> Union[link.LinkFunction, sklearnb.BaseEstimator]:
         _ = self._fit_predict(X, y, fit_mode)
         return self

--- a/cyclic_boosting/features.py
+++ b/cyclic_boosting/features.py
@@ -96,6 +96,9 @@ class Feature(object):
         self.prediction = None
         self.prediction_finite = None
 
+        # set by set_feature_bin_deviations_from_neutral
+        self.bin_weighted_average = None
+
     @property
     def dim(self) -> int:
         """Dimension of the feature group, i.e. the number of its features"""
@@ -269,6 +272,11 @@ class Feature(object):
             self.bin_weightsums = None
         self.unbind_data()
         self.unbind_factor_data()
+
+    def set_feature_bin_deviations_from_neutral(self, neutral_factor_link: float) -> None:
+        weights = np.bincount(self.lex_binned_data, minlength=self.n_bins)
+        weighted_average = np.sum(weights * np.abs(self.factors_link - neutral_factor_link) / np.sum(weights))
+        self.bin_weighted_average = weighted_average
 
 
 def create_feature_id(feature_group_or_id: Union[FeatureID, Any], default_type: Optional[str] = None) -> FeatureID:

--- a/cyclic_boosting/utils.py
+++ b/cyclic_boosting/utils.py
@@ -9,6 +9,8 @@ import pandas as pd
 import six
 import bisect
 
+from typing import Iterable, List
+
 from dataclasses import dataclass
 
 _logger = logging.getLogger(__name__)
@@ -1017,3 +1019,10 @@ class ConvergenceParameters:
 
     def set_delta(self, updated_delta: float) -> None:
         self.delta = updated_delta
+
+
+def get_normalized_values(values: Iterable) -> List[float]:
+    values_total = sum(values)
+    if round(values_total, 6) != 0.0:
+        return [value / values_total for value in values]
+    return [value for value in values]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,3 +68,42 @@ def default_features() -> List[str]:
 @pytest.fixture(scope="session")
 def is_plot() -> bool:
     return False
+
+
+def generate_binned_data(n_samples, n_features=10, seed=123):
+    """
+    Generate uncorrelated binned data for a sales problem.
+
+    :param n_samples: number of samples that ought to be created.
+    :type n_samples: int
+
+    :param seed: random seed used in data creation
+    :type seed: int
+
+    :returns: Randomly generated binned feature matrix and binned target array.
+    :rtype: :obj:`tuple` of :class:`pandas.DataFrame` and
+        :class:`numpy.ndarray`
+
+    """
+    np.random.seed(seed)
+    X = pd.DataFrame()
+    y = np.random.randint(0, 10, n_samples)
+    for i in range(0, n_features):
+        n_bins = np.random.randint(1, 100)
+        X[str(i)] = np.random.randint(0, n_bins, n_samples)
+    return X, y
+
+
+@pytest.fixture(scope="session")
+def get_inputs():
+    n = 10000
+    d = 10
+    X, y = generate_binned_data(n, d)
+    feature_prop = dict(
+        [(str(i), flags.IS_CONTINUOUS) for i in range(5)]
+        + [(str(i), flags.IS_UNORDERED) for i in range(5, 8)]
+        + [("8", flags.IS_CONTINUOUS | flags.IS_LINEAR)]
+        + [("9", flags.IS_CONTINUOUS | flags.IS_SEASONAL)]
+    )
+    feature_groups = [str(i) for i in range(d)] + [("1", "7"), ("2", "4", "8")]
+    return X, y, feature_prop, feature_groups

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,35 @@
+from cyclic_boosting import CBPoissonRegressor
+import numpy as np
+import pytest
+from typing import List
+
+
+@pytest.fixture
+def expected_feature_importances() -> List[float]:
+    return [
+        0.3001108076903618,
+        0.011901588088793208,
+        0.004428680307559594,
+        0.006827823766347157,
+        0.0069619726813944,
+        0.025250911051351754,
+        0.027094558535123603,
+        0.015477424141162243,
+        0.005558373302600022,
+        0.016814438906556692,
+        0.16315611923004458,
+        0.41641730229870494,
+    ]
+
+
+def test_poisson_regressor_feature_importance(get_inputs, expected_feature_importances):
+    X, y, feature_prop, feature_groups = get_inputs
+    est = CBPoissonRegressor(
+        feature_groups=feature_groups,
+        feature_properties=feature_prop,
+    )
+    est.fit(X, y)
+    norm_feature_importances = est.get_feature_importances()
+
+    assert [ele for ele in norm_feature_importances.values()] == expected_feature_importances
+    np.testing.assert_almost_equal(sum(norm_feature_importances.values()), 1.0, 3)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -7,29 +7,37 @@ from typing import List
 @pytest.fixture
 def expected_feature_importances() -> List[float]:
     return [
-        0.3001108076903618,
-        0.011901588088793208,
-        0.004428680307559594,
-        0.006827823766347157,
-        0.0069619726813944,
-        0.025250911051351754,
-        0.027094558535123603,
-        0.015477424141162243,
-        0.005558373302600022,
-        0.016814438906556692,
-        0.16315611923004458,
-        0.41641730229870494,
+        0.08183693583617015,
+        0.14191802307396523,
+        0.12016395453139928,
+        0.23511743026016937,
+        0.10313172776022547,
+        0.030753319720274865,
+        0.09212591146822456,
+        0.19495269734957096,
     ]
 
 
-def test_poisson_regressor_feature_importance(get_inputs, expected_feature_importances):
-    X, y, feature_prop, feature_groups = get_inputs
+def test_poisson_regressor_feature_importance(prepare_data, features, feature_properties, expected_feature_importances):
+    X, y = prepare_data
     est = CBPoissonRegressor(
-        feature_groups=feature_groups,
-        feature_properties=feature_prop,
+        feature_groups=features,
+        feature_properties=feature_properties,
     )
     est.fit(X, y)
     norm_feature_importances = est.get_feature_importances()
 
-    assert [ele for ele in norm_feature_importances.values()] == expected_feature_importances
+    assert [ele[0].feature_group for ele in norm_feature_importances.keys()] == [
+        ("dayofweek",),
+        ("L_ID",),
+        ("PG_ID_3",),
+        ("P_ID",),
+        ("PROMOTION_TYPE",),
+        ("price_ratio",),
+        ("dayofyear",),
+        ("P_ID", "L_ID"),
+    ]
+
+    for ind, f_imp in enumerate(norm_feature_importances.values()):
+        np.testing.assert_almost_equal(f_imp, expected_feature_importances[ind], 4)
     np.testing.assert_almost_equal(sum(norm_feature_importances.values()), 1.0, 3)

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -64,46 +64,8 @@ def temp_dirname_created_and_removed(suffix="", prefix="tmp", base_dir=None):
             shutil.rmtree(dirname)
 
 
-def generate_binned_data(n_samples, n_features=10, seed=123):
-    """
-    Generate uncorrelated binned data for a sales problem.
-
-    :param n_samples: number of samples that ought to be created.
-    :type n_samples: int
-
-    :param seed: random seed used in data creation
-    :type seed: int
-
-    :returns: Randomly generated binned feature matrix and binned target array.
-    :rtype: :obj:`tuple` of :class:`pandas.DataFrame` and
-        :class:`numpy.ndarray`
-
-    """
-    np.random.seed(seed)
-    X = pd.DataFrame()
-    y = np.random.randint(0, 10, n_samples)
-    for i in range(0, n_features):
-        n_bins = np.random.randint(1, 100)
-        X[str(i)] = np.random.randint(0, n_bins, n_samples)
-    return X, y
-
-
-def get_inputs():
-    n = 10000
-    d = 10
-    X, y = generate_binned_data(n, d)
-    feature_prop = dict(
-        [(str(i), flags.IS_CONTINUOUS) for i in range(5)]
-        + [(str(i), flags.IS_UNORDERED) for i in range(5, 8)]
-        + [("8", flags.IS_CONTINUOUS | flags.IS_LINEAR)]
-        + [("9", flags.IS_CONTINUOUS | flags.IS_SEASONAL)]
-    )
-    feature_groups = [str(i) for i in range(d)] + [("1", "7"), ("2", "4", "8")]
-    return X, y, feature_prop, feature_groups
-
-
-def test_analysis_core_regressor():
-    X, y, feature_prop, feature_groups = get_inputs()
+def test_analysis_core_regressor(get_inputs):
+    X, y, feature_prop, feature_groups = get_inputs
     plobs = observers.PlottingObserver()
     est = CBNBinomRegressor(
         feature_groups=feature_groups,
@@ -117,8 +79,8 @@ def test_analysis_core_regressor():
         plots.plot_analysis(plobs, filepath)
 
 
-def test_analysis_poisson_regressor():
-    X, y, feature_prop, feature_groups = get_inputs()
+def test_analysis_poisson_regressor(get_inputs):
+    X, y, feature_prop, feature_groups = get_inputs
     plobs = observers.PlottingObserver()
     est = CBPoissonRegressor(
         feature_groups=feature_groups,
@@ -132,8 +94,8 @@ def test_analysis_poisson_regressor():
         plots.plot_analysis(plobs, filepath)
 
 
-def test_analysis_exponential_regressor():
-    X, y, feature_prop, _fg = get_inputs()
+def test_analysis_exponential_regressor(get_inputs):
+    X, y, feature_prop, _fg = get_inputs
     X["10"] = np.random.uniform(low=0.6, high=1.25, size=len(X))
 
     feature_groups = [str(i) for i in range(9)] + [("1", "7"), ("2", "4", "8")]
@@ -154,8 +116,8 @@ def test_analysis_exponential_regressor():
         plots.plot_analysis(plobs, filepath)
 
 
-def test_analysis_regressor_with_file_handle():
-    X, y, feature_prop, feature_groups = get_inputs()
+def test_analysis_regressor_with_file_handle(get_inputs):
+    X, y, feature_prop, feature_groups = get_inputs
     plobs = observers.PlottingObserver()
     est = CBNBinomRegressor(
         feature_groups=feature_groups,
@@ -172,8 +134,8 @@ def test_analysis_regressor_with_file_handle():
         assert os.path.exists(filepath)
 
 
-def test_analysis_location():
-    X, y, feature_prop, feature_groups = get_inputs()
+def test_analysis_location(get_inputs):
+    X, y, feature_prop, feature_groups = get_inputs
     y = np.sin(y) * 5.3
     plobs = observers.PlottingObserver()
     est = CBLocationRegressor(
@@ -188,8 +150,8 @@ def test_analysis_location():
         plots.plot_analysis(plobs, filepath)
 
 
-def test_analysis_classification():
-    X, y, feature_prop, feature_groups = get_inputs()
+def test_analysis_classification(get_inputs):
+    X, y, feature_prop, feature_groups = get_inputs
     y = y > 5
     plobs = observers.PlottingObserver()
     est = CBClassifier(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 from cyclic_boosting import utils
 
@@ -53,3 +54,22 @@ def test_convergence_parameters():
     cp = utils.ConvergenceParameters()
     assert cp.loss_change == 1e20
     assert cp.delta == 100.0
+
+
+@pytest.mark.parametrize(
+    "values, expected_result",
+    [
+        ([1, 2, 3], [0.16666666666666666, 0.3333333333333333, 0.5]),
+        ([0.0001, 0.000005, 0.000001], [0.9433962264150944, 0.04716981132075472, 0.009433962264150943]),
+        ([0.00, 0.00, 0.00], [0.00, 0.00, 0.00]),
+    ],
+)
+def test_get_normalized_values(values, expected_result):
+    normalized_values = utils.get_normalized_values(values)
+
+    assert normalized_values == expected_result
+
+    if int(sum(normalized_values)):
+        np.testing.assert_almost_equal(sum(normalized_values), 1.0, 6)
+    else:
+        np.testing.assert_almost_equal(sum(normalized_values), 0.0, 6)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,9 +11,9 @@ def plot_CB(filename: str, plobs: list, binner: Optional[BinNumberTransformer] =
         plot_analysis(plot_observer=p, file_obj=filename + "_{}".format(i), use_tightlayout=False, binners=[binner])
 
 
-def costs_mad(prediction, y, weights):
+def costs_mad(prediction: np.ndarray, y: np.ndarray, weights):
     return np.nanmean(np.abs(y - prediction))
 
 
-def costs_mse(prediction, y, weights):
+def costs_mse(prediction: np.ndarray, y: np.ndarray, weights):
     return np.nanmean(np.square(y - prediction))


### PR DESCRIPTION
By including `set_feature_bin_weighted_average` in CyclicBoostingBase `cb_features`. 
I think this is a rather inefficient way of doing this as the feature importances get computed in each iteration of `_fit_main` (https://github.com/Blue-Yonder-OSS/cyclic-boosting/blob/main/cyclic_boosting/base.py#L691), which is redundant as only the final feature importances are required. It was done because:

1. `set_feature_bin_weighted_average ` has to be called before `feature.unbind_data`
2. it avoids introducing a new call to `feature.bind_data(X, weights, False)` 

Alternatively, one could iterate over the features and 1) `bind_data`, 2) compute the weighted average, and then 3) `unbind_data`, for example, here https://github.com/Blue-Yonder-OSS/cyclic-boosting/blob/main/cyclic_boosting/base.py#L724