### PR TITLE
quantile matching

### DIFF
--- a/cyclic_boosting/generic_loss.py
+++ b/cyclic_boosting/generic_loss.py
@@ -13,7 +13,7 @@ from scipy.stats import beta
 
 from cyclic_boosting.base import CyclicBoostingBase, gaussian_matching_by_quantiles, Feature, CBLinkPredictionsFactors
 from cyclic_boosting.link import LogLinkMixin, IdentityLinkMixin, LogitLinkMixin
-from cyclic_boosting.utils import continuous_quantile_from_discrete, get_X_column
+from cyclic_boosting.utils import continuous_cdf_from_discrete_pdf, get_X_column
 from cyclic_boosting.classification import get_beta_priors
 
 from typing import Tuple, Union
@@ -408,7 +408,7 @@ def quantile_global_scale(
     if weights is None:
         raise RuntimeError("The weights have to be initialized.")
 
-    global_scale_link_ = link_func(continuous_quantile_from_discrete(y, quantile))
+    global_scale_link_ = link_func(continuous_cdf_from_discrete_pdf(y, quantile))
 
     prior_pred_link_offset_ = None
     if prior_prediction_column is not None:

--- a/cyclic_boosting/plots/_1dplots.py
+++ b/cyclic_boosting/plots/_1dplots.py
@@ -196,11 +196,10 @@ def plot_factor_1d(
     plot_yp: bool
         Show deviation between truth and prediction in last iteration.
     """
-    try:
-        y = feature.y
-        p = feature.prediction
-    except AttributeError:
+    y = feature.y
+    if y is None:
         plot_yp = False
+    p = feature.prediction
 
     if plot_yp:
         factors = feature.mean_dev

--- a/cyclic_boosting/plots/_2dplots.py
+++ b/cyclic_boosting/plots/_2dplots.py
@@ -103,10 +103,7 @@ def plot_factor_2d(n_bins_finite, feature, grid_item=None):
     from cyclic_boosting.plots import _format_groupname_with_type
 
     plot_yp = True
-    try:
-        _ = feature.y
-        _ = feature.prediction
-    except AttributeError:
+    if feature.y is None:
         plot_yp = False
     if plot_yp:
         y2d = feature.y

--- a/cyclic_boosting/quantile_matching.py
+++ b/cyclic_boosting/quantile_matching.py
@@ -1,0 +1,163 @@
+import numpy as np
+from scipy.optimize import curve_fit
+from scipy.stats import norm, gamma, nbinom
+from scipy.interpolate import InterpolatedUnivariateSpline
+
+from typing import Optional
+
+
+def cdf_fit_gaussian(quantiles: np.ndarray, cdf_values: np.ndarray, mode: Optional[str] = "ppf") -> callable:
+    """
+    Interpolation between pairs of CDF values (potentially estimated by means
+    of quantile regression) and corresponding quantiles according to a
+    Gaussian distribution as assumed PDF.
+
+    Parameters
+    ----------
+    quantiles : np.ndarray
+        quantile values
+    cdf_values : np.ndarray
+        CDF values corresponding to quantile values
+    mode : str
+        decides about kind of returned callable, possible values are:
+
+            - ``ppf``: input quantile, output CDF value (default)
+            - ``dist``: fitted Gaussian (scipy function)
+            - ``cdf``: input CDF value, output quantile
+
+    Returns
+    -------
+    callable
+        fitted Gaussian function (see mode)
+    """
+
+    def f(x, mu, sigma):
+        return norm(loc=mu, scale=sigma).cdf(x)
+
+    mu, sigma = curve_fit(f, cdf_values, quantiles)[0]
+    if mode == "ppf":
+        return norm(mu, sigma).ppf
+    elif mode == "dist":
+        return norm(mu, sigma)
+    elif mode == "cdf":
+        return norm(mu, sigma).cdf
+    else:
+        raise Exception("Invalid mode.")
+
+
+def cdf_fit_gamma(quantiles: np.ndarray, cdf_values: np.ndarray, mode: Optional[str] = "ppf") -> callable:
+    """
+    Interpolation between pairs of CDF values (potentially estimated by means
+    of quantile regression) and corresponding quantiles according to a
+    Gamma distribution as assumed PDF (i.e., continuous, non-negative target
+    values).
+
+    Parameters
+    ----------
+    quantiles : np.ndarray
+        quantile values
+    cdf_values : np.ndarray
+        CDF values corresponding to quantile values
+    mode : str
+        decides about kind of returned callable, possible values are:
+
+            - ``ppf``: input quantile, output CDF value (default)
+            - ``dist``: fitted Gamma (scipy function)
+            - ``cdf``: input CDF value, output quantile
+
+    Returns
+    -------
+    callable
+        fitted Gamma function (see mode)
+    """
+
+    def f(x, alpha, beta):
+        return gamma(alpha, scale=1 / beta).cdf(x)
+
+    alpha, beta = curve_fit(f, cdf_values, quantiles, p0=[2.0, 0.9])[0]
+    if mode == "ppf":
+        return gamma(alpha, scale=1 / beta).ppf
+    elif mode == "dist":
+        return gamma(alpha, scale=1 / beta)
+    elif mode == "cdf":
+        return gamma(alpha, scale=1 / beta).cdf
+    else:
+        raise Exception("Invalid mode.")
+
+
+def _nbinom_cdf_mu_var(x: float, mu: float, var: float) -> callable:
+    """
+    Calculation of negative binomial parameters n and p from given mean and
+    variance, and subsequent call of cumulative distribution function.
+    Parameters
+    ----------
+    x : float
+        value of random variable following a negative binomial distribution
+    mu : float
+        mean of negative binomial distribution
+    var : float
+        variance of negative binomial distribution
+    """
+    n = mu * mu / (var - mu)
+    p = mu / var
+    return nbinom(n, p).cdf(x)
+
+
+def cdf_fit_nbinom(quantiles: np.ndarray, cdf_values: np.ndarray, mode: Optional[str] = "ppf") -> callable:
+    """
+    Interpolation between pairs of CDF values (potentially estimated by means
+    of quantile regression) and corresponding quantiles according to a
+    negative binomial distribution as assumed PDF (i.e., discrete, non-negative
+    target values).
+
+    Parameters
+    ----------
+    quantiles : np.ndarray
+        quantile values
+    cdf_values : np.ndarray
+        CDF values corresponding to quantile values
+    mode : str
+        decides about kind of returned callable, possible values are:
+
+            - ``ppf``: input quantile, output CDF value (default)
+            - ``dist``: fitted negative binomial (scipy function)
+            - ``cdf``: input CDF value, output quantile
+
+    Returns
+    -------
+    callable
+        fitted negative binomial function (see mode)
+    """
+    mu, var = curve_fit(_nbinom_cdf_mu_var, cdf_values, quantiles, p0=[1.2, 1.4])[0]
+    n = mu * mu / (var - mu)
+    p = mu / var
+    if mode == "ppf":
+        return nbinom(n, p).ppf
+    elif mode == "dist":
+        return nbinom(n, p)
+    elif mode == "cdf":
+        return nbinom(n, p).cdf
+    else:
+        raise Exception("Invalid mode.")
+
+
+def cdf_fit_spline(quantiles: np.ndarray, cdf_values: np.ndarray) -> callable:
+    """
+    Interpolation between pairs of CDF values (potentially estimated by means
+    of quantile regression) and corresponding quantiles according to a
+    smoothing spline (i.e., arbitrary target distribution).
+
+    Parameters
+    ----------
+    quantiles : np.ndarray
+        quantile values
+    cdf_values : np.ndarray
+        CDF values corresponding to quantile values
+
+    Returns
+    -------
+    callable
+        fitted spline function (input quantile, output CDF value)
+    """
+    spl = InterpolatedUnivariateSpline(quantiles, cdf_values, k=3, bbox=[0, 1], ext=3)
+    return spl

--- a/cyclic_boosting/utils.py
+++ b/cyclic_boosting/utils.py
@@ -981,9 +981,10 @@ def get_feature_column_names(X, exclude_columns=[]):
     return features
 
 
-def continuous_quantile_from_discrete(y, quantile):
+def continuous_cdf_from_discrete_pdf(y, quantile):
     """
-    Calculates a continous approximation of a given quantile from an array of potentially discrete values.
+    Calculates a continous CDF value approximation for a given quantile from an
+    array of potentially discrete values.
 
     Parameters
     ----------
@@ -995,7 +996,7 @@ def continuous_quantile_from_discrete(y, quantile):
     Returns
     -------
     float
-        calcualted quantile value
+        calculated CDF value
     """
     sorted_y = np.sort(y)
     quantile_index = int(quantile * (len(y) - 1))
@@ -1026,3 +1027,30 @@ def get_normalized_values(values: Iterable) -> List[float]:
     if round(values_total, 6) != 0.0:
         return [value / values_total for value in values]
     return [value for value in values]
+
+
+def smear_discrete_cdftruth(cdf_func: callable, y: int) -> float:
+    """
+    Smearing of the CDF value of a sample from a discrete random variable. Main
+    usage is for a histogram of CDF values to check estimated individual
+    probability distribution (should be flat).
+
+    Parameters
+    ----------
+    y : int
+        value from discrete random variable
+    cdf_func : callable
+        cumulative distribution function
+
+    Returns
+    -------
+    float
+        smeared CDF value for y
+    """
+    cdf_high = cdf_func(y)
+    if y >= 1:
+        cdf_low = cdf_func(y - 1)
+    else:
+        cdf_low = 0.0
+    cdf_truth = cdf_low + np.random.uniform(0, 1) * (cdf_high - cdf_low)
+    return cdf_truth

--- a/docs/source/introduction.md
+++ b/docs/source/introduction.md
@@ -42,6 +42,8 @@ feature bin (as it is the case for the modes mentioned above), it is also
 possible to use another loss function (also possible for classification tasks).
 An important example for this is optimizing for an arbitrary quantile (e.g.,
 the median), aka [quantile regression](https://cyclic-boosting.readthedocs.io/en/latest/cyclic_boosting.html#module-cyclic_boosting.generic_loss).
+By means of several estimated quantiles, one can also approximate full
+individual probability distributions via [quantile matching](https://cyclic-boosting.readthedocs.io/en/latest/cyclic_boosting.html#module-cyclic_boosting.quantile_matching).
 
 Classification
 --------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -443,12 +443,16 @@ def test_multiplicative_quantile_regression_spline(is_plot, prepare_data, featur
     cdf_values = np.asarray(cdf_values)
 
     i = 24
-    spl_fit_cdf = cdf_fit_spline(quantiles, cdf_values[:, i])
+    spl_fit = cdf_fit_spline(quantiles, cdf_values[:, i])
+
+    np.testing.assert_almost_equal(spl_fit(0.2), 0.679, 3)
+    np.testing.assert_almost_equal(spl_fit(0.5), 2.202, 3)
+    np.testing.assert_almost_equal(spl_fit(0.8), 4.297, 3)
 
     if is_plot:
         plt.plot(quantiles, cdf_values[:, i], "ro")
         xs = np.linspace(0, 1, 100)
-        plt.plot(xs, spl_fit_cdf(xs))
+        plt.plot(xs, spl_fit(xs))
         plt.savefig("spline_integration" + str(i) + ".png")
         plt.clf()
 
@@ -475,6 +479,11 @@ def test_multiplicative_quantile_regression_pdf_gamma(is_plot, prepare_data, fea
     n_samples = len(X)
     for i in range(n_samples):
         gamma_fit_cdf = cdf_fit_gamma(quantiles, cdf_values[:, i], mode="cdf")
+        if i == 24:
+            gamma_fit = cdf_fit_gamma(quantiles, cdf_values[:, i])
+            np.testing.assert_almost_equal(gamma_fit(0.2), 0.877, 3)
+            np.testing.assert_almost_equal(gamma_fit(0.5), 2.14, 3)
+            np.testing.assert_almost_equal(gamma_fit(0.8), 4.296, 3)
 
         if is_plot:
             cdf_truth = smear_discrete_cdftruth(gamma_fit_cdf, y[i])
@@ -516,6 +525,11 @@ def test_multiplicative_quantile_regression_pdf_nbinom(is_plot, prepare_data, fe
     n_samples = len(X)
     for i in range(n_samples):
         nbinom_fit_cdf = cdf_fit_nbinom(quantiles, cdf_values[:, i], mode="cdf")
+        if i == 24:
+            nbinom_fit = cdf_fit_nbinom(quantiles, cdf_values[:, i])
+            np.testing.assert_equal(nbinom_fit(0.2), 1)
+            np.testing.assert_equal(nbinom_fit(0.5), 2)
+            np.testing.assert_equal(nbinom_fit(0.8), 4)
 
         if is_plot:
             cdf_truth = smear_discrete_cdftruth(nbinom_fit_cdf, y[i])

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-
+import matplotlib.pyplot as plt
 
 from scipy.special import factorial
 
@@ -20,6 +20,8 @@ from cyclic_boosting.pipelines import (
     pipeline_CBAdditiveGenericCRegressor,
     pipeline_CBGenericClassifier,
 )
+from cyclic_boosting.quantile_matching import cdf_fit_gamma, cdf_fit_nbinom, cdf_fit_spline
+from cyclic_boosting.utils import smear_discrete_cdftruth
 from tests.utils import plot_CB, costs_mad, costs_mse
 
 np.random.seed(42)
@@ -291,9 +293,6 @@ def test_location_regression_default_features(is_plot, feature_properties, defau
     CB_est = pipeline_CBLocationRegressor(feature_properties=fp)
     CB_est.fit(X.copy(), y)
 
-    if is_plot:
-        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
-
     yhat = CB_est.predict(X.copy())
 
     mad = np.nanmean(np.abs(y - yhat))
@@ -342,17 +341,15 @@ def test_GBS_regression_default_features(is_plot, feature_properties, default_fe
     X, y = prepare_data
     X = X[default_features]
 
-    y[1000:10000] = -y[1000:10000]
+    y_GBS = y.copy()
+    y_GBS[1000:10000] = -y_GBS[1000:10000]
 
     CB_est = pipeline_CBGBSRegressor(feature_properties=feature_properties)
-    CB_est.fit(X.copy(), y)
-
-    if is_plot:
-        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
+    CB_est.fit(X.copy(), y_GBS)
 
     yhat = CB_est.predict(X.copy())
 
-    mad = np.nanmean(np.abs(y - yhat))
+    mad = np.nanmean(np.abs(y_GBS - yhat))
     np.testing.assert_almost_equal(mad, 2.5755, 3)
 
 
@@ -388,7 +385,6 @@ def cb_multiplicative_quantile_regressor_model(quantile, features, feature_prope
 
 def test_multiplicative_quantile_regression_median(is_plot, prepare_data, features, feature_properties):
     X, y = prepare_data
-    y = abs(y)
 
     quantile = 0.5
     CB_est = cb_multiplicative_quantile_regressor_model(
@@ -411,7 +407,6 @@ def test_multiplicative_quantile_regression_median(is_plot, prepare_data, featur
 
 def test_multiplicative_quantile_regression_90(is_plot, prepare_data, features, feature_properties):
     X, y = prepare_data
-    y = abs(y)
 
     quantile = 0.9
     CB_est = cb_multiplicative_quantile_regressor_model(
@@ -429,6 +424,117 @@ def test_multiplicative_quantile_regression_90(is_plot, prepare_data, features, 
     np.testing.assert_almost_equal(quantile_acc, 0.9015, 3)
 
 
+@pytest.mark.skip(reason="Long running time")
+def test_multiplicative_quantile_regression_spline(is_plot, prepare_data, features, feature_properties):
+    X, y = prepare_data
+
+    quantiles = []
+    cdf_values = []
+    for quantile in [0.1, 0.3, 0.5, 0.7, 0.9]:
+        CB_est = cb_multiplicative_quantile_regressor_model(
+            quantile=quantile, features=features, feature_properties=feature_properties
+        )
+        CB_est.fit(X.copy(), y)
+        yhat = CB_est.predict(X.copy())
+        cdf_values.append(yhat)
+        quantiles.append(quantile)
+
+    quantiles = np.asarray(quantiles)
+    cdf_values = np.asarray(cdf_values)
+
+    i = 24
+    spl_fit_cdf = cdf_fit_spline(quantiles, cdf_values[:, i])
+
+    if is_plot:
+        plt.plot(quantiles, cdf_values[:, i], "ro")
+        xs = np.linspace(0, 1, 100)
+        plt.plot(xs, spl_fit_cdf(xs))
+        plt.savefig("spline_integration" + str(i) + ".png")
+        plt.clf()
+
+
+@pytest.mark.skip(reason="Long running time")
+def test_multiplicative_quantile_regression_pdf_gamma(is_plot, prepare_data, features, feature_properties):
+    X, y = prepare_data
+
+    quantiles = []
+    cdf_values = []
+    for quantile in [0.1, 0.3, 0.5, 0.7, 0.9]:
+        CB_est = cb_multiplicative_quantile_regressor_model(
+            quantile=quantile, features=features, feature_properties=feature_properties
+        )
+        CB_est.fit(X.copy(), y)
+        yhat = CB_est.predict(X.copy())
+        cdf_values.append(yhat)
+        quantiles.append(quantile)
+
+    quantiles = np.asarray(quantiles)
+    cdf_values = np.asarray(cdf_values)
+
+    cdf_truth_list = []
+    n_samples = len(X)
+    for i in range(n_samples):
+        gamma_fit_cdf = cdf_fit_gamma(quantiles, cdf_values[:, i], mode="cdf")
+
+        if is_plot:
+            cdf_truth = smear_discrete_cdftruth(gamma_fit_cdf, y[i])
+            cdf_truth_list.append(cdf_truth)
+
+            if i == 24:
+                plt.plot(cdf_values[:, i], quantiles, "ro")
+                xs = np.linspace(0, cdf_values[:, i].max(), 100)
+                plt.plot(xs, gamma_fit_cdf(xs))
+                plt.savefig("gamma_integration_" + str(i) + ".png")
+                plt.clf()
+
+    cdf_truth = np.asarray(cdf_truth_list)
+    if is_plot:
+        plt.hist(cdf_truth[cdf_truth > 0], bins=30)
+        plt.savefig("gamma_cdf_truth_histo.png")
+        plt.clf()
+
+
+@pytest.mark.skip(reason="Long running time")
+def test_multiplicative_quantile_regression_pdf_nbinom(is_plot, prepare_data, features, feature_properties):
+    X, y = prepare_data
+
+    quantiles = []
+    cdf_values = []
+    for quantile in [0.1, 0.3, 0.5, 0.7, 0.9]:
+        CB_est = cb_multiplicative_quantile_regressor_model(
+            quantile=quantile, features=features, feature_properties=feature_properties
+        )
+        CB_est.fit(X.copy(), y)
+        yhat = CB_est.predict(X.copy())
+        cdf_values.append(yhat)
+        quantiles.append(quantile)
+
+    quantiles = np.asarray(quantiles)
+    cdf_values = np.asarray(cdf_values)
+
+    cdf_truth_list = []
+    n_samples = len(X)
+    for i in range(n_samples):
+        nbinom_fit_cdf = cdf_fit_nbinom(quantiles, cdf_values[:, i], mode="cdf")
+
+        if is_plot:
+            cdf_truth = smear_discrete_cdftruth(nbinom_fit_cdf, y[i])
+            cdf_truth_list.append(cdf_truth)
+
+            if i == 24:
+                plt.plot(cdf_values[:, i], quantiles, "ro")
+                xs = np.linspace(0, cdf_values[:, i].max(), 100)
+                plt.plot(xs, nbinom_fit_cdf(xs))
+                plt.savefig("nbinom_integration_" + str(i) + ".png")
+                plt.clf()
+
+    cdf_truth = np.asarray(cdf_truth_list)
+    if is_plot:
+        plt.hist(cdf_truth, bins=30)
+        plt.savefig("nbinom_cdf_truth_histo.png")
+        plt.clf()
+
+
 def test_additive_quantile_regression_median(is_plot, prepare_data, default_features, feature_properties):
     X, y = prepare_data
     X = X[default_features]
@@ -439,16 +545,13 @@ def test_additive_quantile_regression_median(is_plot, prepare_data, default_feat
     )
     CB_est.fit(X.copy(), y)
 
-    if is_plot:
-        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
-
     yhat = CB_est.predict(X.copy())
 
     quantile_acc = evaluate_quantile(y, yhat)
-    np.testing.assert_almost_equal(quantile_acc, 0.5007, 3)
+    np.testing.assert_almost_equal(quantile_acc, 0.4973, 3)
 
     mad = np.nanmean(np.abs(y - yhat))
-    np.testing.assert_almost_equal(mad, 2.5565, 3)
+    np.testing.assert_almost_equal(mad, 1.6991, 3)
 
 
 def test_additive_quantile_regression_90(is_plot, prepare_data, default_features, feature_properties):
@@ -460,9 +563,6 @@ def test_additive_quantile_regression_90(is_plot, prepare_data, default_features
         quantile=0.9,
     )
     CB_est.fit(X.copy(), y)
-
-    if is_plot:
-        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
     yhat = CB_est.predict(X.copy())
 
@@ -480,13 +580,10 @@ def test_additive_regression_mad(is_plot, prepare_data, default_features, featur
     )
     CB_est.fit(X.copy(), y)
 
-    if is_plot:
-        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
-
     yhat = CB_est.predict(X.copy())
 
     mad = np.nanmean(np.abs(y - yhat))
-    np.testing.assert_almost_equal(mad, 2.5565, 3)
+    np.testing.assert_almost_equal(mad, 1.6991, 3)
 
 
 def test_additive_regression_mse(is_plot, prepare_data, default_features, feature_properties):
@@ -499,18 +596,14 @@ def test_additive_regression_mse(is_plot, prepare_data, default_features, featur
     )
     CB_est.fit(X.copy(), y)
 
-    if is_plot:
-        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
-
     yhat = CB_est.predict(X.copy())
 
     mad = np.nanmean(np.abs(y - yhat))
-    np.testing.assert_almost_equal(mad, 2.5735, 3)
+    np.testing.assert_almost_equal(mad, 1.748, 3)
 
 
 def test_multiplicative_regression_mad(is_plot, prepare_data, default_features, feature_properties):
     X, y = prepare_data
-    y = abs(y)
 
     X = X[default_features]
 
@@ -520,9 +613,6 @@ def test_multiplicative_regression_mad(is_plot, prepare_data, default_features, 
     )
     CB_est.fit(X.copy(), y)
 
-    if is_plot:
-        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
-
     yhat = CB_est.predict(X.copy())
 
     mad = np.nanmean(np.abs(y - yhat))
@@ -531,7 +621,6 @@ def test_multiplicative_regression_mad(is_plot, prepare_data, default_features, 
 
 def test_multiplicative_regression_mse(is_plot, prepare_data, default_features, feature_properties):
     X, y = prepare_data
-    y = abs(y)
 
     X = X[default_features]
 
@@ -540,9 +629,6 @@ def test_multiplicative_regression_mse(is_plot, prepare_data, default_features, 
         costs=costs_mse,
     )
     CB_est.fit(X.copy(), y)
-
-    if is_plot:
-        plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
     yhat = CB_est.predict(X.copy())
 
@@ -617,4 +703,4 @@ def test_classification_logloss(is_plot, prepare_data, cb_classifier_logloss_mod
     yhat = CB_est.predict(X.copy())
 
     mad = np.nanmean(np.abs(y - yhat))
-    np.testing.assert_almost_equal(mad, 0.3811, 3)
+    np.testing.assert_almost_equal(mad, 0.408, 3)

--- a/tests/test_quantile_matching.py
+++ b/tests/test_quantile_matching.py
@@ -1,0 +1,112 @@
+import numpy as np
+from scipy.stats import norm, gamma, nbinom
+import matplotlib.pyplot as plt
+
+from cyclic_boosting.quantile_matching import cdf_fit_gaussian, cdf_fit_gamma, cdf_fit_nbinom, cdf_fit_spline
+
+
+def test_cdf_fit_gaussian(is_plot):
+    quantiles = np.array([0.1, 0.3, 0.5, 0.7, 0.9])
+    mu_exp = 0.3
+    sigma_exp = 1.4
+    cdf_values = norm.ppf(quantiles, mu_exp, sigma_exp)
+
+    gaussian_fit_quantiles = cdf_fit_gaussian(quantiles, cdf_values)
+    np.testing.assert_almost_equal(gaussian_fit_quantiles(0.2), -0.878, 3)
+    np.testing.assert_almost_equal(gaussian_fit_quantiles(0.5), 0.3, 3)
+    np.testing.assert_almost_equal(gaussian_fit_quantiles(0.8), 1.478, 3)
+
+    gaussian_fit_quantiles_pdf = cdf_fit_gaussian(quantiles, cdf_values, mode="dist")
+    np.testing.assert_almost_equal(gaussian_fit_quantiles_pdf.mean(), mu_exp, 3)
+    np.testing.assert_almost_equal(gaussian_fit_quantiles_pdf.std(), sigma_exp, 3)
+
+    gaussian_fit_quantiles_cdf = cdf_fit_gaussian(quantiles, cdf_values, mode="cdf")
+    np.testing.assert_almost_equal(gaussian_fit_quantiles_cdf(-0.9), 0.196, 3)
+    np.testing.assert_almost_equal(gaussian_fit_quantiles_cdf(0.3), 0.5, 3)
+    np.testing.assert_almost_equal(gaussian_fit_quantiles_cdf(1.5), 0.804, 3)
+
+    if is_plot:
+        plt.plot(cdf_values, quantiles, "ro")
+        xs = np.linspace(cdf_values.min(), cdf_values.max(), 100)
+        plt.plot(xs, gaussian_fit_quantiles_cdf(xs))
+        plt.savefig("gaussian.png")
+        plt.clf()
+
+
+def test_cdf_fit_gamma(is_plot):
+    quantiles = np.array([0.1, 0.3, 0.5, 0.7, 0.9])
+    mu_exp = 2.3
+    sigma_exp = 1.4
+    alpha_exp = mu_exp * mu_exp / (sigma_exp * sigma_exp)
+    beta_exp = mu_exp / (sigma_exp * sigma_exp)
+    cdf_values = gamma.ppf(quantiles, alpha_exp, scale=1 / beta_exp)
+
+    gamma_fit_quantiles = cdf_fit_gamma(quantiles, cdf_values)
+    np.testing.assert_almost_equal(gamma_fit_quantiles(0.2), 1.12, 3)
+    np.testing.assert_almost_equal(gamma_fit_quantiles(0.5), 2.023, 3)
+    np.testing.assert_almost_equal(gamma_fit_quantiles(0.8), 3.322, 3)
+
+    gamma_fit_quantiles_pdf = cdf_fit_gamma(quantiles, cdf_values, mode="dist")
+    np.testing.assert_almost_equal(gamma_fit_quantiles_pdf.mean(), mu_exp, 3)
+    np.testing.assert_almost_equal(gamma_fit_quantiles_pdf.std(), sigma_exp, 3)
+
+    gamma_fit_quantiles_cdf = cdf_fit_gamma(quantiles, cdf_values, mode="cdf")
+    np.testing.assert_almost_equal(gamma_fit_quantiles_cdf(1.1), 0.194, 3)
+    np.testing.assert_almost_equal(gamma_fit_quantiles_cdf(2.0), 0.493, 3)
+    np.testing.assert_almost_equal(gamma_fit_quantiles_cdf(3.3), 0.796, 3)
+
+    if is_plot:
+        plt.plot(cdf_values, quantiles, "ro")
+        xs = np.linspace(0, cdf_values.max(), 100)
+        plt.plot(xs, gamma_fit_quantiles_cdf(xs))
+        plt.savefig("gamma.png")
+        plt.clf()
+
+
+def test_cdf_fit_nbinom(is_plot):
+    quantiles = np.array([0.1, 0.3, 0.5, 0.7, 0.9])
+    mu_exp = 5.3
+    sigma_exp = 3.1
+    n_exp = mu_exp * mu_exp / (sigma_exp * sigma_exp - mu_exp)
+    p_exp = mu_exp / (sigma_exp * sigma_exp)
+    cdf_values = nbinom.ppf(quantiles, n_exp, p_exp)
+
+    np.random.seed(42)
+    nbinom_fit_quantiles = cdf_fit_nbinom(quantiles, cdf_values)
+    np.testing.assert_equal(nbinom_fit_quantiles(0.2), 3.0)
+    np.testing.assert_equal(nbinom_fit_quantiles(0.5), 5.0)
+    np.testing.assert_equal(nbinom_fit_quantiles(0.8), 8.0)
+
+    nbinom_fit_quantiles_pdf = cdf_fit_nbinom(quantiles, cdf_values, mode="dist")
+    np.testing.assert_almost_equal(nbinom_fit_quantiles_pdf.mean(), 5.850, 3)
+    np.testing.assert_almost_equal(nbinom_fit_quantiles_pdf.std(), 3.234, 3)
+
+    nbinom_fit_quantiles_cdf = cdf_fit_nbinom(quantiles, cdf_values, mode="cdf")
+    np.testing.assert_almost_equal(nbinom_fit_quantiles_cdf(3), 0.251, 3)
+    np.testing.assert_almost_equal(nbinom_fit_quantiles_cdf(5), 0.51, 3)
+    np.testing.assert_almost_equal(nbinom_fit_quantiles_cdf(8), 0.809, 3)
+    np.testing.assert_almost_equal(nbinom_fit_quantiles_cdf(8.2), 0.809, 3)
+
+    if is_plot:
+        plt.plot(cdf_values, quantiles, "ro")
+        xs = np.linspace(0, cdf_values.max(), 100)
+        plt.plot(xs, nbinom_fit_quantiles_cdf(xs))
+        plt.savefig("nbinom.png")
+        plt.clf()
+
+
+def test_cdf_fit_spline(is_plot):
+    quantiles = np.array([0.1, 0.3, 0.5, 0.7, 0.9])
+    cdf_values = np.array([-1.7, 0.3, 1.5, 2.7, 5.8])
+
+    spl = cdf_fit_spline(quantiles, cdf_values)
+    np.testing.assert_almost_equal(spl(0.2), -0.567, 3)
+    np.testing.assert_almost_equal(spl(0.5), 1.5, 3)
+    np.testing.assert_almost_equal(spl(0.8), 3.877, 3)
+
+    if is_plot:
+        plt.plot(quantiles, cdf_values, "ro")
+        xs = np.linspace(0, 1, 100)
+        plt.plot(xs, spl(xs))
+        plt.savefig("spline.png")
+        plt.clf()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,7 +39,7 @@ def test_get_feature_column_names():
     np.testing.assert_equal(features, ["b", "c"])
 
 
-def test_continuous_quantile_from_discrete():
+def continuous_cdf_from_discrete_pdf():
     y = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     quantile_value = utils.continuous_quantile_from_discrete(y, 0.8)
     assert quantile_value == 8.0


### PR DESCRIPTION
In order to get a full individual probability distribution from a few quantile estimates, the CDF of an assumed probability distribution (or a smoothing spline for an unknown underlying distribution) is fitted to the quantile predictions.
Also, this fixes a few minor plotting issues introduced in recent updates.