### PR TITLE
make binning inplace optional

### DIFF
--- a/cyclic_boosting/base.py
+++ b/cyclic_boosting/base.py
@@ -360,7 +360,6 @@ class CyclicBoostingBase(
 
         X: np.ndarray
             samples features matrix
-
         """
         if self.weight_column is None:
             self.weights = np.ones(len(X))

--- a/cyclic_boosting/binning/bin_number_transformer.py
+++ b/cyclic_boosting/binning/bin_number_transformer.py
@@ -11,6 +11,8 @@ from ._binary_search import eq_multi, ge_multi
 from ._utils import _read_feature_property, check_frame_empty
 from .ecdf_transformer import ECdfTransformer
 
+from typing import Union, Optional
+
 MISSING_VALUE_AS_BINNO = -1
 
 _logger = logging.getLogger(__name__)
@@ -174,7 +176,9 @@ class BinNumberTransformer(ECdfTransformer):
             xt = MISSING_VALUE_AS_BINNO
         return xt
 
-    def transform(self, X_orig, y=None):
+    def transform(
+        self, X_orig: Union[pd.DataFrame, np.ndarray], y: Optional[np.ndarray] = None
+    ) -> Union[pd.DataFrame, np.ndarray]:
         self._check_input_for_transform(X_orig)
 
         if not self.inplace:
@@ -185,7 +189,6 @@ class BinNumberTransformer(ECdfTransformer):
         if check_frame_empty(X):
             if isinstance(X, pd.DataFrame):
                 X = X.astype({col: np.int8 for col, _, _ in self.bins_and_cdfs_})
-
             else:
                 return _as_int_array_of_minimum_dtype(X)
 

--- a/cyclic_boosting/binning/bin_number_transformer.py
+++ b/cyclic_boosting/binning/bin_number_transformer.py
@@ -124,6 +124,7 @@ class BinNumberTransformer(ECdfTransformer):
         weight_column=None,
         epsilon=1e-9,
         tolerance=0.1,
+        inplace=False,
     ):
         self.n_bins = n_bins
         self.feature_properties = feature_properties
@@ -131,6 +132,7 @@ class BinNumberTransformer(ECdfTransformer):
         self.epsilon = epsilon
         self.tolerance = tolerance
         self.nan_representation = MISSING_VALUE_AS_BINNO
+        self.inplace = inplace
         ECdfTransformer.__init__(
             self,
             n_bins=self.n_bins,
@@ -172,8 +174,13 @@ class BinNumberTransformer(ECdfTransformer):
             xt = MISSING_VALUE_AS_BINNO
         return xt
 
-    def transform(self, X, y=None):
-        self._check_input_for_transform(X)
+    def transform(self, X_orig, y=None):
+        self._check_input_for_transform(X_orig)
+
+        if not self.inplace:
+            X = X_orig.copy()
+        else:
+            X = X_orig
 
         if check_frame_empty(X):
             if isinstance(X, pd.DataFrame):

--- a/cyclic_boosting/pipelines.py
+++ b/cyclic_boosting/pipelines.py
@@ -48,6 +48,7 @@ def pipeline_CB(
     regalpha=0.0,
     quantile=None,
     costs=None,
+    inplace=False,
 ):
     if estimator in [CBPoissonRegressor, CBLocPoissonRegressor, CBLocationRegressor, CBClassifier]:
         estimatorCB = estimator(
@@ -171,7 +172,7 @@ def pipeline_CB(
         )
     else:
         raise Exception("No valid CB estimator.")
-    binner = binning.BinNumberTransformer(n_bins=number_of_bins, feature_properties=feature_properties)
+    binner = binning.BinNumberTransformer(n_bins=number_of_bins, feature_properties=feature_properties, inplace=inplace)
 
     return Pipeline([("binning", binner), ("CB", estimatorCB)])
 

--- a/docs/source/tutorial.md
+++ b/docs/source/tutorial.md
@@ -155,16 +155,16 @@ from cyclic_boosting.pipelines import pipeline_CBMultiplicativeQuantileRegressor
 from cyclic_boosting.quantile_matching import J_QPD_S
 
 CB_est_qlow = pipeline_CBMultiplicativeQuantileRegressor(quantile=0.2)
-CB_est_qlow.fit(X_train.copy(), y)
-yhat_qlow = CB_est_qlow.predict(X_test.copy())
+CB_est_qlow.fit(X_train, y)
+yhat_qlow = CB_est_qlow.predict(X_test)
 
 CB_est_qmedian = pipeline_CBMultiplicativeQuantileRegressor(quantile=0.5)
-CB_est_qmedian.fit(X_train.copy(), y)
-yhat_qmedian = CB_est_qmedian.predict(X_test.copy())
+CB_est_qmedian.fit(X_train, y)
+yhat_qmedian = CB_est_qmedian.predict(X_test)
 
 CB_est_qhigh = pipeline_CBMultiplicativeQuantileRegressor(quantile=0.8)
-CB_est_qhigh.fit(X_train.copy(), y)
-yhat_qhigh = CB_est_qhigh.predict(X_test.copy())
+CB_est_qhigh.fit(X_train, y)
+yhat_qhigh = CB_est_qhigh.predict(X_test)
 
 j_qpd_s_42 = J_QPD_S(0.2, yhat_qlow[42], yhat_qmedian[42], yhat_qhigh[42])
 yhat_42_percentile95 = j_qpd_s_42.ppf(0.95)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -56,13 +56,13 @@ def test_poisson_regression(is_plot, prepare_data, cb_poisson_regressor_model):
     X, y = prepare_data
 
     CB_est = cb_poisson_regressor_model
-    CB_est.fit(X.copy(), y)
+    CB_est.fit(X, y)
 
     if is_plot:
         plot_CB("analysis_CB_iterfirst", [CB_est[-1].observers[0]], CB_est[-2])
         plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     mad = np.nanmean(np.abs(y - yhat))
     np.testing.assert_almost_equal(mad, 1.70, 3)
@@ -108,13 +108,13 @@ def test_poisson_regression_ordered_smoothing(is_plot, prepare_data, cb_poisson_
     X_special["P_ID"].iloc[1] = 11.5
 
     CB_est = cb_poisson_regressor_model_ordered_smoothing
-    CB_est.fit(X_special.copy(), y)
+    CB_est.fit(X_special, y)
 
     if is_plot:
         plot_CB("analysis_CB_iterfirst_ordered", [CB_est[-1].observers[0]], CB_est[-2])
         plot_CB("analysis_CB_iterlast_ordered", [CB_est[-1].observers[-1]], CB_est[-2])
 
-    yhat = CB_est.predict(X_special.copy())
+    yhat = CB_est.predict(X_special)
 
     mad = np.nanmean(np.abs(y - yhat))
     np.testing.assert_almost_equal(mad, 1.70, 3)
@@ -169,14 +169,14 @@ def test_poisson_regression_hierarchical(is_plot, prepare_data, cb_poisson_regre
     X, y = prepare_data
 
     CB_est = cb_poisson_regressor_model_hierarchical
-    CB_est.fit(X.copy(), y)
+    CB_est.fit(X, y)
 
     if is_plot:
         plot_CB("analysis_CB_iterfirst", [CB_est[-1].observers[0]], CB_est[-2])
         plot_CB("analysis_CB_iterfourth", [CB_est[-1].observers[1]], CB_est[-2])
         plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     mad = np.nanmean(np.abs(y - yhat))
     np.testing.assert_almost_equal(mad, 1.699, 3)
@@ -187,9 +187,9 @@ def test_poisson_regression_default_features(prepare_data, default_features, fea
     X = X[default_features]
 
     CB_est = pipeline_CBPoissonRegressor(feature_properties=feature_properties)
-    CB_est.fit(X.copy(), y)
+    CB_est.fit(X, y)
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     mad = np.nanmean(np.abs(y - yhat))
     np.testing.assert_almost_equal(mad, 1.7185, 3)
@@ -201,9 +201,9 @@ def test_poisson_regression_ndarray(prepare_data, default_features, feature_prop
     X = X[default_features].to_numpy()
 
     CB_est = pipeline_CBPoissonRegressor(feature_groups=feature_groups, feature_properties=feature_properties)
-    CB_est.fit(X.copy(), y)
+    CB_est.fit(X, y)
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     mad = np.nanmean(np.abs(y - yhat))
     np.testing.assert_almost_equal(mad, expected, 3)
@@ -227,8 +227,8 @@ def test_regression_ndarray_w_feature_properties(prepare_data, default_features,
     else:
         CB_est = pipeline_CBPoissonRegressor(feature_properties=fp)
 
-    CB_est.fit(X.copy(), y)
-    yhat = CB_est.predict(X.copy())
+    CB_est.fit(X, y)
+    yhat = CB_est.predict(X)
     mad = np.nanmean(np.abs(y - yhat))
     np.testing.assert_almost_equal(mad, 1.697, 3)
 
@@ -244,13 +244,13 @@ def test_poisson_regression_default_features_and_properties(is_plot, prepare_dat
     CB_est = pipeline_CBPoissonRegressor(
         observers=plobs,
     )
-    CB_est.fit(X.copy(), y)
+    CB_est.fit(X, y)
 
     if is_plot:
         plot_CB("analysis_CB_iterfirst", [CB_est[-1].observers[0]], CB_est[-2])
         plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     mad = np.nanmean(np.abs(y - yhat))
     np.testing.assert_almost_equal(mad, 1.6982, 3)
@@ -261,9 +261,9 @@ def test_poisson_regression_default_features_notaggregated(prepare_data, default
     X = X[default_features]
 
     CB_est = pipeline_CBPoissonRegressor(feature_properties=feature_properties, aggregate=False)
-    CB_est.fit(X.copy(), y)
+    CB_est.fit(X, y)
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     mad = np.nanmean(np.abs(y - yhat))
     np.testing.assert_almost_equal(mad, 1.7144, 3)
@@ -278,9 +278,9 @@ def test_nbinom_regression_default_features(prepare_data, default_features, feat
         a=1.2,
         c=0.1,
     )
-    CB_est.fit(X.copy(), y)
+    CB_est.fit(X, y)
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     mad = np.nanmean(np.abs(y - yhat))
     np.testing.assert_almost_equal(mad, 1.7198, 3)
@@ -296,9 +296,9 @@ def test_nbinom_regression_ndarray(prepare_data, default_features, feature_prope
         feature_groups=feature_groups,
         feature_properties=fp,
     )
-    CB_est.fit(X.copy(), y)
+    CB_est.fit(X, y)
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     mad = np.nanmean(np.abs(y - yhat))
     np.testing.assert_almost_equal(mad, expected, 3)
@@ -348,13 +348,13 @@ def test_exponential_regression(is_plot, prepare_data, cb_exponential_regressor_
     X.loc[X["price_ratio"] == np.nan, "price_ratio"] = 1.0
 
     CB_est = cb_exponential_regressor_model
-    CB_est.fit(X.copy(), y)
+    CB_est.fit(X, y)
 
     if is_plot:
         plot_CB("analysis_CB_iterfirst", [CB_est[-1].observers[0]], CB_est[-2])
         plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     mad = np.nanmean(np.abs(y - yhat))
     np.testing.assert_almost_equal(mad, 1.7203, 3)
@@ -387,12 +387,12 @@ def test_classification(is_plot, prepare_data, cb_classifier_model):
     y = y >= 3
 
     CB_est = cb_classifier_model
-    CB_est.fit(X.copy(), y)
+    CB_est.fit(X, y)
 
     if is_plot:
         plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     mad = np.nanmean(np.abs(y - yhat))
     np.testing.assert_almost_equal(mad, 0.3075, 3)
@@ -405,9 +405,9 @@ def test_location_regression_default_features(is_plot, feature_properties, defau
     fp = feature_properties
 
     CB_est = pipeline_CBLocationRegressor(feature_properties=fp)
-    CB_est.fit(X.copy(), y)
+    CB_est.fit(X, y)
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     mad = np.nanmean(np.abs(y - yhat))
     np.testing.assert_almost_equal(mad, 1.7511, 3)
@@ -441,13 +441,13 @@ def test_width_regression_default_features(feature_properties, default_features,
 
     fp = feature_properties
     CB_est = pipeline_CBPoissonRegressor(feature_properties=fp)
-    CB_est.fit(X.copy(), y)
-    yhat = CB_est.predict(X.copy())
+    CB_est.fit(X, y)
+    yhat = CB_est.predict(X)
     X = X.assign(yhat_mean=yhat)
 
     CB_est_width = cb_width_model
-    CB_est_width.fit(X.copy(), y)
-    c = CB_est_width.predict(X.copy())
+    CB_est_width.fit(X, y)
+    c = CB_est_width.predict(X)
     np.testing.assert_almost_equal(c.mean(), 0.365, 3)
 
 
@@ -459,9 +459,9 @@ def test_GBS_regression_default_features(is_plot, feature_properties, default_fe
     y_GBS[1000:10000] = -y_GBS[1000:10000]
 
     CB_est = pipeline_CBGBSRegressor(feature_properties=feature_properties)
-    CB_est.fit(X.copy(), y_GBS)
+    CB_est.fit(X, y_GBS)
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     mad = np.nanmean(np.abs(y_GBS - yhat))
     np.testing.assert_almost_equal(mad, 2.5755, 3)
@@ -504,13 +504,13 @@ def test_multiplicative_quantile_regression_median(is_plot, prepare_data, featur
     CB_est = cb_multiplicative_quantile_regressor_model(
         quantile=quantile, features=features, feature_properties=feature_properties
     )
-    CB_est.fit(X.copy(), y)
+    CB_est.fit(X, y)
 
     if is_plot:
         plot_CB("analysis_CB_iterfirst", [CB_est[-1].observers[0]], CB_est[-2])
         plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     quantile_acc = evaluate_quantile(y, yhat)
     np.testing.assert_almost_equal(quantile_acc, 0.5043, 3)
@@ -526,13 +526,13 @@ def test_multiplicative_quantile_regression_90(is_plot, prepare_data, features, 
     CB_est = cb_multiplicative_quantile_regressor_model(
         quantile=quantile, features=features, feature_properties=feature_properties
     )
-    CB_est.fit(X.copy(), y)
+    CB_est.fit(X, y)
 
     if is_plot:
         plot_CB("analysis_CB_iterfirst", [CB_est[-1].observers[0]], CB_est[-2])
         plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     quantile_acc = evaluate_quantile(y, yhat)
     np.testing.assert_almost_equal(quantile_acc, 0.9015, 3)
@@ -550,8 +550,8 @@ def test_multiplicative_quantile_regression_pdf_J_QPD_S(is_plot, prepare_data, f
         CB_est = cb_multiplicative_quantile_regressor_model(
             quantile=quantile, features=features, feature_properties=feature_properties
         )
-        CB_est.fit(X.copy(), y)
-        yhat = CB_est.predict(X.copy())
+        CB_est.fit(X, y)
+        yhat = CB_est.predict(X)
         quantile_values.append(yhat)
         quantiles.append(quantile)
 
@@ -597,8 +597,8 @@ def test_multiplicative_quantile_regression_spline(is_plot, prepare_data, featur
         CB_est = cb_multiplicative_quantile_regressor_model(
             quantile=quantile, features=features, feature_properties=feature_properties
         )
-        CB_est.fit(X.copy(), y)
-        yhat = CB_est.predict(X.copy())
+        CB_est.fit(X, y)
+        yhat = CB_est.predict(X)
         quantile_values.append(yhat)
         quantiles.append(quantile)
 
@@ -629,8 +629,8 @@ def test_multiplicative_quantile_regression_pdf_gamma(is_plot, prepare_data, fea
         CB_est = cb_multiplicative_quantile_regressor_model(
             quantile=quantile, features=features, feature_properties=feature_properties
         )
-        CB_est.fit(X.copy(), y)
-        yhat = CB_est.predict(X.copy())
+        CB_est.fit(X, y)
+        yhat = CB_est.predict(X)
         quantile_values.append(yhat)
         quantiles.append(quantile)
 
@@ -675,8 +675,8 @@ def test_multiplicative_quantile_regression_pdf_nbinom(is_plot, prepare_data, fe
         CB_est = cb_multiplicative_quantile_regressor_model(
             quantile=quantile, features=features, feature_properties=feature_properties
         )
-        CB_est.fit(X.copy(), y)
-        yhat = CB_est.predict(X.copy())
+        CB_est.fit(X, y)
+        yhat = CB_est.predict(X)
         quantile_values.append(yhat)
         quantiles.append(quantile)
 
@@ -719,9 +719,9 @@ def test_additive_quantile_regression_median(is_plot, prepare_data, default_feat
         feature_properties=feature_properties,
         quantile=0.5,
     )
-    CB_est.fit(X.copy(), y)
+    CB_est.fit(X, y)
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     quantile_acc = evaluate_quantile(y, yhat)
     np.testing.assert_almost_equal(quantile_acc, 0.4950, 3)
@@ -738,9 +738,9 @@ def test_additive_quantile_regression_90(is_plot, prepare_data, default_features
         feature_properties=feature_properties,
         quantile=0.9,
     )
-    CB_est.fit(X.copy(), y)
+    CB_est.fit(X, y)
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     quantile_acc = evaluate_quantile(y, yhat)
     np.testing.assert_almost_equal(quantile_acc, 0.8934, 3)
@@ -760,12 +760,12 @@ def test_additive_regression_mad(is_plot, prepare_data, default_features, featur
         costs=costs_mad,
         observers=plobs,
     )
-    CB_est.fit(X.copy(), y)
+    CB_est.fit(X, y)
 
     if is_plot:
         plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     mad = np.nanmean(np.abs(y - yhat))
     np.testing.assert_almost_equal(mad, 1.7062, 3)
@@ -779,9 +779,9 @@ def test_additive_regression_mse(is_plot, prepare_data, default_features, featur
         feature_properties=feature_properties,
         costs=costs_mse,
     )
-    CB_est.fit(X.copy(), y)
+    CB_est.fit(X, y)
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     mad = np.nanmean(np.abs(y - yhat))
     np.testing.assert_almost_equal(mad, 1.738, 3)
@@ -796,9 +796,9 @@ def test_multiplicative_regression_mad(is_plot, prepare_data, default_features, 
         feature_properties=feature_properties,
         costs=costs_mad,
     )
-    CB_est.fit(X.copy(), y)
+    CB_est.fit(X, y)
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     mad = np.nanmean(np.abs(y - yhat))
     np.testing.assert_almost_equal(mad, 1.6705, 3)
@@ -813,9 +813,9 @@ def test_multiplicative_regression_mse(is_plot, prepare_data, default_features, 
         feature_properties=feature_properties,
         costs=costs_mse,
     )
-    CB_est.fit(X.copy(), y)
+    CB_est.fit(X, y)
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     mad = np.nanmean(np.abs(y - yhat))
     np.testing.assert_almost_equal(mad, 1.7171, 3)
@@ -835,12 +835,12 @@ def test_multiplicative_regression_likelihood(is_plot, prepare_data, default_fea
         feature_properties=feature_properties,
         costs=poisson_likelihood,
     )
-    CB_est.fit(X.copy(), y)
+    CB_est.fit(X, y)
 
     if is_plot:
         plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     mad = np.nanmean(np.abs(y - yhat))
     np.testing.assert_almost_equal(mad, 1.9310, 3)
@@ -880,12 +880,12 @@ def test_classification_logloss(is_plot, prepare_data, cb_classifier_logloss_mod
     y = y >= 3
 
     CB_est = cb_classifier_logloss_model
-    CB_est.fit(X.copy(), y)
+    CB_est.fit(X, y)
 
     if is_plot:
         plot_CB("analysis_CB_iterlast", [CB_est[-1].observers[-1]], CB_est[-2])
 
-    yhat = CB_est.predict(X.copy())
+    yhat = CB_est.predict(X)
 
     mad = np.nanmean(np.abs(y - yhat))
     np.testing.assert_almost_equal(mad, 0.404, 3)


### PR DESCRIPTION
If binning is not set to be inplace (default is False, what means changing a copy of the original X), the Cyclic Boosting pipeline is not changing X (what is usually a desirable bahavior).
Before, a copy before calling the Cyclic Boosting pipeline was needed to keep the original X.
This is an interface change.